### PR TITLE
Adding note about type error for sets (and dicts), and allow custom --gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ By default, the generated source files will be written to the `src` directory,
 but you can change that using the `thrift_output` option.
 
 You can also pass additional options to the Thrift compiler by listing them in
-the `thrift_options` option.
+the `thrift_options` option:
+
+```elixir
+thrift_options: ~w[-I my/include/dir]
+```
 
 If you require a specific version of the Thrift compiler, you can specify a
 version requirement using the `thrift_version` option. Version requirements
@@ -53,6 +57,15 @@ use the [SemVer 2.0 schema][semver]. For example:
 ```elixir
 thrift_version: ">= 0.9.3"  # Erlang maps support
 ```
+
+
+If you get something like `type set() undefined` when compiling the generated files
+you can try:
+
+```elixir
+thrift_options: ~w[--gen erl:maps]
+```
+
 
 ## Thrift IDL Parsing
 


### PR DESCRIPTION
Had issue compiling the the generated erlang due to these two errors

```
type dict() undefined
type set() undefined
```
The dict and set types where non-namespaced in the generated hrl (`set()` instead of `sets:set()`) so I'm guessing the default thrift erl options is `otp16`.

From the `thrift -help`:
```
  erl (Erlang):
    legacynames: Output files retain naming conventions of Thrift 0.9.1 and earlier.
    maps:        Generate maps instead of dicts.
    otp16:       Generate non-namespaced dict and set instead of dict:dict and sets:set.
```

Most people probably want `maps` instead.
I added a note about the type error and suggests a custom `thrift_options`,
and made sure that `--gen erl` is only added to the system call when `--gen` is not in the `thrift_options` to allow people to set it themselves.