### PR TITLE
Add a test suite for Mix.Tasks.Compile.Thrift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /deps
 /doc
 /src/thrift_lexer.erl
+/test/fixtures/app/src
 erl_crash.dump
 *.ez
 log.*

--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -1,0 +1,9 @@
+defmodule App.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :app,
+     version: "1.0.0",
+     thrift_files: Mix.Utils.extract_files(["thrift"], [:thrift])]
+  end
+end

--- a/test/fixtures/app/thrift/shared.thrift
+++ b/test/fixtures/app/thrift/shared.thrift
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This Thrift file can be included by other Thrift files that want to share
+ * these definitions.
+ */
+
+namespace cpp shared
+namespace d share // "shared" would collide with the eponymous D keyword.
+namespace dart shared
+namespace java shared
+namespace perl shared
+namespace php shared
+namespace haxe shared
+
+struct SharedStruct {
+  1: i32 key
+  2: string value
+}
+
+service SharedService {
+  SharedStruct getStruct(1: i32 key)
+}

--- a/test/fixtures/app/thrift/tutorial.thrift
+++ b/test/fixtures/app/thrift/tutorial.thrift
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+# Thrift Tutorial
+# Mark Slee (mcslee@facebook.com)
+#
+# This file aims to teach you how to use Thrift, in a .thrift file. Neato. The
+# first thing to notice is that .thrift files support standard shell comments.
+# This lets you make your thrift file executable and include your Thrift build
+# step on the top line. And you can place comments like this anywhere you like.
+#
+# Before running this file, you will need to have installed the thrift compiler
+# into /usr/local/bin.
+
+/**
+ * The first thing to know about are types. The available types in Thrift are:
+ *
+ *  bool        Boolean, one byte
+ *  byte        Signed byte
+ *  i16         Signed 16-bit integer
+ *  i32         Signed 32-bit integer
+ *  i64         Signed 64-bit integer
+ *  double      64-bit floating point value
+ *  string      String
+ *  binary      Blob (byte array)
+ *  map<t1,t2>  Map from one type to another
+ *  list<t1>    Ordered list of one type
+ *  set<t1>     Set of unique elements of one type
+ *
+ * Did you also notice that Thrift supports C style comments?
+ */
+
+// Just in case you were wondering... yes. We support simple C comments too.
+
+/**
+ * Thrift files can reference other Thrift files to include common struct
+ * and service definitions. These are found using the current path, or by
+ * searching relative to any paths specified with the -I compiler flag.
+ *
+ * Included objects are accessed using the name of the .thrift file as a
+ * prefix. i.e. shared.SharedObject
+ */
+include "shared.thrift"
+
+/**
+ * Thrift files can namespace, package, or prefix their output in various
+ * target languages.
+ */
+namespace cpp tutorial
+namespace d tutorial
+namespace dart tutorial
+namespace java tutorial
+namespace php tutorial
+namespace perl tutorial
+namespace haxe tutorial
+
+/**
+ * Thrift lets you do typedefs to get pretty names for your types. Standard
+ * C style here.
+ */
+typedef i32 MyInteger
+
+/**
+ * Thrift also lets you define constants for use across languages. Complex
+ * types and structs are specified using JSON notation.
+ */
+const i32 INT32CONSTANT = 9853
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+/**
+ * You can define enums, which are just 32 bit integers. Values are optional
+ * and start at 1 if not supplied, C style again.
+ */
+enum Operation {
+  ADD = 1,
+  SUBTRACT = 2,
+  MULTIPLY = 3,
+  DIVIDE = 4
+}
+
+/**
+ * Structs are the basic complex data structures. They are comprised of fields
+ * which each have an integer identifier, a type, a symbolic name, and an
+ * optional default value.
+ *
+ * Fields can be declared "optional", which ensures they will not be included
+ * in the serialized output if they aren't set.  Note that this requires some
+ * manual management in some languages.
+ */
+struct Work {
+  1: i32 num1 = 0,
+  2: i32 num2,
+  3: Operation op,
+  4: optional string comment,
+}
+
+/**
+ * Structs can also be exceptions, if they are nasty.
+ */
+exception InvalidOperation {
+  1: i32 whatOp,
+  2: string why
+}
+
+/**
+ * Ahh, now onto the cool part, defining a service. Services just need a name
+ * and can optionally inherit from another service using the extends keyword.
+ */
+service Calculator extends shared.SharedService {
+
+  /**
+   * A method definition looks like C code. It has a return type, arguments,
+   * and optionally a list of exceptions that it may throw. Note that argument
+   * lists and exception lists are specified using the exact same syntax as
+   * field lists in struct or exception definitions.
+   */
+
+   void ping(),
+
+   i32 add(1:i32 num1, 2:i32 num2),
+
+   i32 calculate(1:i32 logid, 2:Work w) throws (1:InvalidOperation ouch),
+
+   /**
+    * This method has a oneway modifier. That means the client only makes
+    * a request and does not listen for any response at all. Oneway methods
+    * must be void.
+    */
+   oneway void zip()
+
+}
+
+/**
+ * That just about covers the basics. Take a look in the test/ folder for more
+ * detailed examples. After you run this file, your generated code shows up
+ * in folders with names gen-<language>. The generated code isn't too scary
+ * to look at. It even has pretty indentation.
+ */

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -1,0 +1,80 @@
+defmodule Mix.Tasks.Compile.ThriftTest do
+  use ExUnit.Case
+
+  import Mix.Tasks.Compile.Thrift, only: [run: 1]
+  import ExUnit.CaptureIO
+
+  @fixture_project Path.expand("../../fixtures/app", __DIR__)
+
+  setup do
+    in_fixture(fn -> File.rm_rf!("src") end)
+    :ok
+  end
+
+  test "compiling default :thrift_files" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        assert capture_io(fn -> run([]) end) =~ """
+          Compiled thrift/shared.thrift
+          Compiled thrift/tutorial.thrift
+          """
+        assert File.exists?("src/shared_types.hrl")
+        assert File.exists?("src/tutorial_types.hrl")
+      end
+    end
+  end
+
+  test "recompiling unchanged targets" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        assert capture_io(fn -> run([]) end) =~ "Compiled thrift/tutorial.thrift"
+        assert capture_io(fn -> run([]) end) == ""
+      end
+    end
+  end
+
+  test "recompiling stale targets" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        assert capture_io(fn -> run([]) end) =~ "Compiled thrift/tutorial.thrift"
+        File.rm_rf!("src")
+        assert capture_io(fn -> run([]) end) =~ "Compiled thrift/tutorial.thrift"
+      end
+    end
+  end
+
+  test "forcing compilation" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        assert capture_io(fn -> run([]) end) =~ "Compiled thrift/tutorial.thrift"
+        assert capture_io(fn -> run(["--force"]) end) =~ "Compiled thrift/tutorial.thrift"
+      end
+    end
+  end
+
+  test "specifying an empty :thrift_files list " do
+    in_fixture fn ->
+      with_project_config [thrift_files: []], fn ->
+        assert capture_io(fn -> run([]) end) == ""
+      end
+    end
+  end
+
+  test "attempting to use an unsupported Thrift version" do
+    in_fixture fn ->
+      with_project_config [thrift_version: "< 0.0.0"], fn ->
+        assert_raise Mix.Error, ~r/^Unsupported Thrift version/, fn ->
+          run([])
+        end
+      end
+    end
+  end
+
+  defp in_fixture(fun) do
+    File.cd!(@fixture_project, fun)
+  end
+
+  defp with_project_config(config, fun) do
+    Mix.Project.in_project(:app, @fixture_project, config, fn(_) -> fun.() end)
+  end
+end


### PR DESCRIPTION
These tests rely on a working thrift compiler being available in the current
test environment, but that's a reasonable requirement because it's also a
prerequisite for using this mix task in the first place.