### PR TITLE
An implementation of the Thrift parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /deps
 /doc
 /src/thrift_lexer.erl
+/src/thrift_parser.erl
 /test/fixtures/app/src
 erl_crash.dump
 *.ez

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,6 +1,7 @@
 {
   "skip_files": [
     "ext",
-    "src/thrift_lexer.erl"
+    "src/thrift_lexer.erl",
+    "src/thrift_parser.erl"
   ]
 }

--- a/lib/parser/models.ex
+++ b/lib/parser/models.ex
@@ -1,0 +1,473 @@
+  defmodule Thrift.Parser.Types do
+    defmodule Primitive do
+      @type t :: :bool | :i8 | :i16 | :i64 | :binary | :double | :byte | :string
+    end
+
+    defmodule Ident do
+      @type t :: String.t
+    end
+
+    defmodule Standalone do
+      @type t :: Ident.t | Primitive.t
+    end
+
+    defmodule List do
+      @type t :: {:list, Thrift.Parser.Types.t}
+    end
+
+    defmodule Map do
+      @type t  :: {:map, {Thrift.Parser.Types.t, Thrift.Parser.Types.t}}
+    end
+
+    defmodule Set do
+      @type t :: {:set, Thrift.Parser.Types.t}
+    end
+
+    defmodule Container do
+      @type t :: List.t | Map.t | Set.t
+    end
+
+    @type t :: Container.t | Standalone.t
+  end
+
+  defmodule Thrift.Parser.Literals do
+    defmodule Primitive do
+      @type t :: integer | boolean | String.t | float
+    end
+
+    defmodule List do
+      @type t :: [Thrift.Parser.Literals.t]
+    end
+
+    defmodule Map do
+      @type t :: %{Thrift.Parser.Literals.t => Thrift.Parser.Literals.t}
+    end
+
+    defmodule Container do
+      @type t :: Map.t | List.t
+    end
+
+    @type t :: Container.t | Primitive.t
+    @type s :: atom
+  end
+
+  defmodule Thrift.Parser.Conversions do
+    def atomify(nil), do: nil
+    def atomify(l) when is_list(l) do
+      List.to_atom(l)
+    end
+
+    def cast(_, nil) do
+      nil
+    end
+
+    def cast(:double, val) do
+      val
+    end
+
+    def cast(:string, val) do
+      List.to_string(val)
+    end
+
+    def cast({:set, type}, val) do
+      MapSet.new(val, &cast(type, &1))
+    end
+
+    def cast({:map, {key_type, val_type}}, val) do
+      Enum.into(val, %{}, fn {k, v} ->
+        {cast(key_type, k), cast(val_type, v)}
+      end)
+    end
+
+    def cast(_, val) do
+      val
+    end
+  end
+
+  defmodule Thrift.Parser.Models do
+    alias Thrift.Parser.Types
+    alias Thrift.Parser.Literals
+
+    defmodule Namespace do
+      @moduledoc """
+      A Thrift namespace.
+      The namespace is a language-specific place where the generated structs are
+      placed.
+      """
+
+      @type t :: %Namespace{name: String.t, path: String.t}
+      defstruct name: nil, path: nil
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list, char_list) :: %Namespace{}
+      def new(name, path) do
+        %Namespace{name: atomify(name), path: List.to_string(path)}
+      end
+    end
+
+    defmodule Include do
+      @moduledoc """
+      An included file.
+      In Thrift, you can include other files to share structs, enums and the like.
+      """
+
+      @type t :: %Include{path: String.t}
+      defstruct path: nil
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list) :: %Include{}
+      def new(path) do
+        %Include{path: List.to_string(path)}
+      end
+    end
+
+    defmodule Constant do
+      @moduledoc """
+      A Thrift constant.
+      Constants of any primitive or container type can be created in Thrift.
+      """
+
+      @type t :: %Constant{name: String.t, value: Literal.t, type: Types.t}
+      defstruct name: nil, value: nil, type: nil
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list, Literals.t, Types.t) :: %Constant{}
+      def new(name, val, type) do
+        %Constant{name: atomify(name), value: cast(type, val), type: type}
+      end
+    end
+
+    defmodule TEnum do
+      @moduledoc """
+      A Thrift enumeration
+      An enumeration contains names and (usually sequential) values, and
+      allows you to map from one to the other.
+      """
+
+      @type enum_value :: bitstring | integer
+      @type t :: %TEnum{name: String.t, values: %{String.t => enum_value}}
+      defstruct name: nil, values: []
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list, %{char_list => enum_value}) :: %TEnum{}
+      def new(name, values) do
+        values = values
+        |> Enum.with_index
+        |> Enum.map(fn
+          {{name, value}, _index} ->
+            {atomify(name),  value}
+
+          {name, index} ->
+            {atomify(name), index + 1}
+        end)
+
+        %TEnum{name: atomify(name), values: values}
+      end
+    end
+
+    defmodule Field do
+      @moduledoc """
+      A Thrift field.
+
+      Fields define a named type and can occur in functions, structs, unions,
+      exceptions and the parameter list and `throws` clauses of functions.
+
+      Fields can refer to each other. These are represented by the FieldReference
+      type.
+
+      This module also contains some utilities for validating and fixing up fields.
+      """
+
+      @type printable :: String.t | atom
+      @type t :: %Field{id: integer, name: String.t, type: Types.t,
+                        required: boolean, default: Literals.t}
+      defstruct id: nil, name: nil, type: nil, required: :default, default: nil
+
+      import Thrift.Parser.Conversions
+
+      @spec new(integer, boolean, Types.t, char_list, Literals.t) :: %Field{}
+      def new(id, required, type, name, default) do
+        %Field{id: id,
+               type: type,
+               name: atomify(name),
+               required: required,
+               default: cast(type, default)}
+      end
+
+      @spec build_field_list(printable, [%Field{}]) :: [%Field{}]
+      def build_field_list(parent_name, fields) do
+        fields
+        |> update_ids(parent_name)
+        |> validate_ids(parent_name)
+      end
+
+      defp validate_ids(fields, name) do
+        dupes = fields
+        |> Enum.group_by(&(&1.id))
+        |> Enum.filter(fn {_, v} -> length(v) > 1 end)
+
+        unless Enum.empty?(dupes) do
+          {id, fields} = List.first(dupes)
+
+          names = fields
+          |> Enum.map(&("#{name}.#{&1.name}"))
+          |> Enum.join(", ")
+
+          raise "Error: #{names} share field number #{id}."
+        end
+
+        fields
+      end
+
+      defp update_ids(fields, parent_name) do
+        alias Thrift.Parser.Shell
+        fields
+        |> Enum.with_index
+        |> Enum.map(fn
+          {field=%__MODULE__{}, idx} ->
+            case field.id do
+              nil ->
+                Shell.warn "Warning: id not set for field '#{parent_name}.#{field.name}'."
+                %__MODULE__{field | id: idx + 1}
+              _ ->
+                field
+            end
+        end)
+      end
+    end
+
+    defmodule Exception do
+      @moduledoc """
+      A Thrift exception
+
+      Exceptions can happen when the remote service encounters an error.
+      """
+
+      @type t :: %Exception{name: String.t, fields: [%Field{}]}
+      defstruct fields: %{}, name: nil
+
+      import Thrift.Parser.Conversions
+      alias Thrift.Parser.Models.Field
+
+      @spec new(char_list, [%Field{}, ...]) :: %Exception{}
+      def new(name, fields) do
+        ex_name = atomify(name)
+        updated_fields = Field.build_field_list(ex_name, fields)
+
+        %Exception{name: ex_name, fields: updated_fields}
+      end
+    end
+
+    defmodule Struct do
+      @moduledoc """
+      A Thrift struct
+
+      The basic datastructure in Thrift, structs have aa name and a field list.
+      """
+
+      @type t :: %Struct{name: String.t, fields: %{String.t => %Field{}}}
+      defstruct name: nil, fields: %{}
+
+      import Thrift.Parser.Conversions
+      alias Thrift.Parser.Models.Field
+
+      @spec new(char_list, [%Field{}, ...]) :: %Struct{}
+      def new(name, fields) do
+        struct_name = atomify(name)
+        fields = Field.build_field_list(struct_name, fields)
+
+        %Struct{name: struct_name, fields: fields}
+      end
+    end
+
+    defmodule Union do
+      @moduledoc """
+      A Thrift union
+
+      Unions can have one field set at a time.
+      """
+
+      @type t :: %Union{name: String.t, fields: %{String.t => %Field{}}}
+      defstruct name: nil, fields: %{}
+
+      import Thrift.Parser.Conversions
+      alias Thrift.Parser.Models.Field
+
+      @spec new(char_list, [%Field{}, ...]) :: %Union{}
+      def new(name, fields) do
+        name = atomify(name)
+        fields = Field.build_field_list(name, fields)
+        |> Enum.map(fn(field=%Field{}) ->
+          # According to Thrift docs, unions have implicitly optional
+          # fields. See https://thrift.apache.org/docs/idl#union
+          %Field{field | required: false}
+        end)
+
+        %Union{name: name, fields: fields}
+      end
+    end
+
+    defmodule StructRef do
+      @moduledoc """
+      A reference to another struct.
+
+      While not a Thrift type, this represents when a Thrift type refers to
+      another.
+      """
+
+      @type t :: %StructRef{referenced_type: String.t}
+      defstruct referenced_type: nil
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list) :: %StructRef{}
+      def new(referenced_type) do
+        %StructRef{referenced_type: atomify(referenced_type)}
+      end
+    end
+
+    defmodule Function do
+      @moduledoc """
+      A Thrift function
+
+      Functions are remote endpoints for Thrift services. They contain an argument list, exceptions and return a typed object.
+      They can also be `oneway`, which means that Thrift doesn't have to wait for
+      a reply from them.
+      """
+
+      @type return :: :void | Types.t
+      @type t :: %Function{oneway: boolean, return_type: return, name: String.t,
+                           params: [%Field{}], exceptions: [%Exception{}]}
+      defstruct oneway: false, return_type: :void, name: nil, params: [], exceptions: []
+      alias Thrift.Parser.Models.Field
+      import Thrift.Parser.Conversions
+
+      @spec new(boolean, Types.t, char_list, [%Field{}, ...], [%Exception{}, ...]) :: %Function{}
+      def new(oneway, return_type, name, params, exceptions) do
+        name = atomify(name)
+        params = Field.build_field_list(name, params)
+
+        %Function{
+          oneway: oneway,
+          return_type: return_type,
+          name: name,
+          params: params,
+          exceptions: exceptions
+        }
+      end
+    end
+
+    defmodule Service do
+      @moduledoc """
+      A Thrift service
+
+      Services hold RPC functions and can extend other services.
+      """
+
+      @type t :: %Service{name: String.t, extends: String.t, functions: [%Function{}]}
+      defstruct name: nil, extends: nil, functions: []
+
+      import Thrift.Parser.Conversions
+
+      @spec new(char_list, [%Function{}, ...], char_list) :: %Service{}
+      def new(name, functions, extends) do
+        %Service{name: atomify(name), extends: atomify(extends), functions: functions}
+      end
+    end
+
+    defmodule Schema do
+      @moduledoc """
+      A Thrift schema.
+
+      A program represents a single parsed file in Thrift.
+      Many programs can be compiled together to build a Thrift service.
+
+      This is the root datastructure that the parser emits after running.
+      """
+
+      @type header :: %Include{} | %Namespace{}
+      @type typedef :: {:typedef, Types.t, atom}
+      @type definition :: %Service{} | %TEnum{} | %Exception{} | %Union{} | %Struct{} | %Constant{} | typedef
+      @type t :: %Schema{
+        thrift_namespace: String.t,
+        namespaces: %{String.t => %Namespace{}},
+        structs: %{String.t => %Struct{}},
+        services: %{String.t => %Service{}},
+        enums: %{String.t => %TEnum{}},
+        unions: %{String.t => %Union{}},
+        includes: [%Include{}],
+        constants: %{String.t => Literals.t},
+        exceptions: %{String.t => %Exception{}},
+        typedefs: %{String.t => Types.t}
+      }
+      defstruct thrift_namespace: nil,
+      namespaces: %{},
+      structs: %{},
+      services: %{},
+      enums: %{},
+      unions: %{},
+      includes: [],
+      constants: %{},
+      exceptions: %{},
+      typedefs: %{}
+
+      import Thrift.Parser.Conversions
+      alias Thrift.Parser.Models.Include
+      alias Thrift.Parser.Models.Namespace
+      alias Thrift.Parser.Models.Constant
+      alias Thrift.Parser.Models.Exception
+      alias Thrift.Parser.Models.Struct
+      alias Thrift.Parser.Models.TEnum
+      alias Thrift.Parser.Models.Union
+
+      @doc """
+      Constructs a schema with both headers and definitions.
+      """
+      @spec new([header], [definition]) :: %Schema{}
+      def new(headers, defs) do
+        program = headers
+        |> Enum.reverse
+        |> Enum.reduce(
+          %Schema{},
+          fn
+            (inc=%Include{}, program) ->
+              %Schema{program | includes: [inc | program.includes]}
+
+            (ns=%Namespace{}, program) ->
+              %Schema{program | namespaces: Map.put(program.namespaces, ns.name, ns)}
+          end)
+
+        defs
+        |> Enum.reverse
+        |> Enum.reduce(
+          program,
+          fn
+            (const=%Constant{}, program) ->
+              %Schema{program | constants: Map.put(program.constants, const.name, const)}
+
+            (enum=%TEnum{}, program) ->
+              %Schema{program | enums: Map.put(program.enums, enum.name, enum)}
+
+            (exc=%Exception{}, program) ->
+              %Schema{program | exceptions: Map.put(program.exceptions, exc.name, exc)}
+
+            ({:typedef, actual_type, type_alias}, program) ->
+              %Schema{program | typedefs: Map.put(program.typedefs, atomify(type_alias), actual_type)}
+
+            (struct=%Struct{}, program) ->
+              %Schema{program | structs: Map.put(program.structs, struct.name, struct)}
+            (union=%Union{}, program) ->
+              %Schema{program | unions: Map.put(program.unions, union.name, union)}
+
+            (service=%Service{}, program) ->
+              %Schema{program | services: Map.put(program.services, service.name, service)}
+          end)
+      end
+    end
+
+    @type all :: %Namespace{} | %Include{} | %Constant{} | %TEnum{} | %Field{} | %Exception{} | %Struct{} | %Union{} | %Function{} | %Service{} | %Schema{}
+  end

--- a/lib/parser/parser.ex
+++ b/lib/parser/parser.ex
@@ -1,0 +1,45 @@
+defmodule Thrift.Parser do
+  @type path_element :: String.t | atom
+
+  alias Thrift.Parser.Models
+  alias Thrift.Parser.Models.Schema
+
+  @doc """
+  Parses a Thrift document and returns the schema that it represents.
+  """
+  @spec parse(String.t) :: %Schema{}
+  def parse(doc) do
+    doc = String.to_char_list(doc)
+
+    {:ok, tokens, _} = :thrift_lexer.string(doc)
+    {:ok, parse_tree} = :thrift_parser.parse(tokens)
+
+    parse_tree
+  end
+
+  @doc """
+  Parses a Thrift document and returns a component to the caller.
+
+  The part of the thrift document that's returned is determined by
+  the `path` parameter. It works a lot like the `find_in` function,
+  which takes a map and can pull out nested pieces.
+
+  This makes it easy to get to a service definition:
+
+      parse(doc, [:services, :MyService])
+
+  Will return the "MyService" service.
+  """
+  @spec parse(String.t, [path_element]) :: Models.all
+  def parse(doc, path) do
+    program = parse(doc)
+
+    Enum.reduce(path, program, fn
+      (_part, nil) ->
+        nil
+      (part, next=%{}) ->
+        Map.get(next, part)
+    end)
+  end
+
+end

--- a/lib/parser/shell.ex
+++ b/lib/parser/shell.ex
@@ -1,0 +1,13 @@
+defmodule Thrift.Parser.Shell do
+  @yellow IO.ANSI.yellow
+  @red IO.ANSI.red
+  @reset IO.ANSI.reset
+
+  def warn(msg) do
+    IO.puts "#{@yellow}#{msg}#{@reset}"
+  end
+
+  def error(msg) do
+    IO.puts "#{@red}#{msg}#{@reset}"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Thrift.Mixfile do
      # Build Environment
      erlc_paths: ["src", "ext/thrift/lib/erl/src"],
      erlc_include_path: "ext/thrift/lib/erl/include",
-     compilers: [:leex, :erlang, :elixir, :app],
+     compilers: [:leex, :yecc, :erlang, :elixir, :app],
 
      # Testing
      test_coverage: [tool: ExCoveralls],
@@ -40,7 +40,9 @@ defmodule Thrift.Mixfile do
   defp deps do
      [{:ex_doc, "~> 0.11.4", only: :dev},
       {:earmark, "~> 0.2.1", only: :dev},
-      {:excoveralls, "~> 0.5.4", only: :test}]
+      {:excoveralls, "~> 0.5.4", only: :test},
+      {:dialyze, "~> 0.2.0", only: [:dev, :test]}
+     ]
   end
 
   defp description do
@@ -58,6 +60,7 @@ defmodule Thrift.Mixfile do
       files: ~w(README.md LICENSE mix.exs lib) ++
              ~w(ext/thrift/CHANGES ext/thrift/LICENSE ext/thrift/NOTICE) ++
              ~w(ext/thrift/README.md ext/thrift/doc ext/thrift/lib/erl) ++
-             ~w(src/thrift_lexer.xrl)]
+             ~w(src/thrift_lexer.xrl src/thrift_parser.yrl)
+     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.4", "1a6e116bcf980da8b7fe33140c1d7e61aa0a4e51951cadbfacc420c12d2b9b8f", [:mix], [{:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}, {:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}]},

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -7,13 +7,25 @@ HEX             = [+-]?0x[0-9A-Fa-f]+
 DOUBLE          = [+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?
 IDENTIFIER      = [a-zA-Z_](\.[a-zA-Z_0-9]|[a-zA-Z_0-9])*
 ST_IDENTIFIER   = [a-zA-Z-](\.[a-zA-Z_0-9-]|[a-zA-Z_0-9-])*
-SYMBOL          = [:;\,\{\}\(\)\=<>\[\]]
+SEMI            = [;]
 WHITESPACE      = [\s\t\r\n]+
 COMMENT         = //[^\n]*
 CCOMMENT        = /\\*/*([^*/]|[^*]/|\\*[^/])*\\**\\*/
 UNIXCOMMENT     = #[^\n]*
 STRING1         = '(\\\^.|\\.|[^'])*'
 STRING2         = "(\\\^.|\\.|[^"])*"
+OPEN_CURLY      = [\{]
+CLOSE_CURLY     = [\}]
+LT              = [<]
+GT              = [>]
+COMMA           = [,]
+COLON           = [:]
+OPEN_BRACKET    = [\[]
+CLOSE_BRACKET   = [\]]
+OPEN_PAREN      = [\(]
+CLOSE_PAREN     = [\)]
+EQUALS          = [=]
+ASTERISK        = [*]
 
 Rules.
 
@@ -21,9 +33,20 @@ Rules.
 {COMMENT}       : skip_token.
 {CCOMMENT}      : skip_token.
 {UNIXCOMMENT}   : skip_token.
+{SEMI}          : skip_token.
 
-{SYMBOL}        : {token, {symbol, TokenLine, TokenChars}}.
-
+{ASTERISK}      : {token, {'*', TokenLine}}.
+{OPEN_CURLY}    : {token, {'{', TokenLine}}.
+{CLOSE_CURLY}   : {token, {'}', TokenLine}}.
+{OPEN_BRACKET}  : {token, {'[', TokenLine}}.
+{CLOSE_BRACKET} : {token, {']', TokenLine}}.
+{OPEN_PAREN}    : {token, {'(', TokenLine}}.
+{CLOSE_PAREN}   : {token, {')', TokenLine}}.
+{EQUALS}        : {token, {'=', TokenLine}}.
+{GT}            : {token, {'>', TokenLine}}.
+{LT}            : {token, {'<', TokenLine}}.
+{COMMA}         : {token, {',', TokenLine}}.
+{COLON}         : {token, {':', TokenLine}}.
 namespace       : {token, {namespace, TokenLine}}.
 include         : {token, {include, TokenLine}}.
 

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -1,0 +1,206 @@
+
+Nonterminals
+schema
+headers header
+definitions definition
+namespace_def constant_def include_def
+type base_type literal set_type map_type list_type literal_list
+
+mapping mappings
+
+enum_def enum_body enum_value
+exception_def
+fields field_spec field_sep field_required field_id field_default
+typedef_def
+ns_name
+struct_def union_def service_def
+functions function
+service_extends
+oneway_marker
+return_type
+throws_clause.
+
+Terminals
+'*' '{' '}' '[' ']' '(' ')' '=' '>' '<' ',' ':'
+namespace
+include
+ident
+int
+double
+const
+bool
+byte
+i8
+i16
+i32
+i64
+string
+binary
+list
+map
+set
+enum
+exception
+required
+optional
+typedef
+struct
+union
+service
+extends
+oneway
+void
+throws.
+
+
+Rootsymbol schema.
+
+schema ->
+    headers definitions:
+        'Elixir.Thrift.Parser.Models.Schema':new('$1', '$2').
+
+headers -> '$empty': [].
+headers -> header headers: ['$1'] ++ '$2'.
+
+header -> namespace_def: '$1'.
+header -> include_def: '$1'.
+
+definitions -> '$empty': [].
+definitions -> definition definitions: ['$1'] ++ '$2'.
+
+definition -> constant_def: '$1'.
+definition -> enum_def: '$1'.
+definition -> exception_def: '$1'.
+definition -> typedef_def: '$1'.
+definition -> struct_def: '$1'.
+definition -> union_def: '$1'.
+definition -> service_def: '$1'.
+
+type -> base_type: '$1'.
+type -> set_type: {set, '$1'}.
+type -> map_type: {map, '$1'}.
+type -> list_type: {list, '$1'}.
+type -> ident: 'Elixir.Thrift.Parser.Models.StructRef':new(unwrap('$1')).
+
+base_type -> bool: bool.
+base_type -> byte: i8.
+base_type -> i8: i8.
+base_type -> i16: i16.
+base_type -> i32: i32.
+base_type -> i64: i64.
+base_type -> double: double.
+base_type -> string: string.
+base_type -> binary: binary.
+
+set_type -> set '<' type '>': '$3'.
+map_type -> map '<' type ',' type '>': {'$3', '$5'}.
+list_type -> list '<' type '>': '$3'.
+
+include_def ->
+    include string:
+        'Elixir.Thrift.Parser.Models.Include':new(unwrap('$2')).
+
+namespace_def ->
+    namespace ns_name ident:
+        'Elixir.Thrift.Parser.Models.Namespace':new('$2', unwrap('$3')).
+
+constant_def ->
+    const type ident '=' literal:
+        'Elixir.Thrift.Parser.Models.Constant':new(unwrap('$3'), '$5', '$2').
+
+ns_name -> '*': "*".
+ns_name -> ident: unwrap('$1').
+
+
+%% JS Style mapping "foo": 32
+mapping -> literal ':' literal: {'$1', '$3'}.
+mappings -> mapping: ['$1'].
+mappings -> mapping ',' mappings: ['$1'] ++ '$3'.
+
+% A list of literals ["hi", "bye", 3, 4]
+literal_list -> literal: ['$1'].
+literal_list -> literal ',' literal_list: ['$1'] ++ '$3'.
+
+literal -> int: unwrap('$1').
+literal -> double: unwrap('$1').
+literal -> string: unwrap('$1').
+literal -> '{' literal_list '}': '$2'.
+literal -> '{' mappings '}': '$2'.
+literal -> '[' literal_list ']': '$2'.
+
+field_sep -> '$empty': nil.
+field_sep -> ',': nil.
+
+enum_def ->
+    enum ident '{' enum_body '}':
+        'Elixir.Thrift.Parser.Models.TEnum':new(unwrap('$2'), '$4').
+enum_body -> enum_value field_sep: ['$1'].
+enum_body -> enum_value field_sep enum_body: ['$1'] ++ '$3'.
+
+enum_value -> ident: unwrap('$1').
+enum_value -> ident '=' int: {unwrap('$1'), unwrap('$3')}.
+
+exception_def ->
+    exception ident '{' fields '}':
+        'Elixir.Thrift.Parser.Models.Exception':new(unwrap('$2'), '$4').
+
+fields -> '$empty': [].
+fields -> field_spec field_sep fields: ['$1'] ++ '$3'.
+
+field_id -> int ':': unwrap('$1').
+field_id -> '$empty': nil.
+
+field_spec ->
+    field_id field_required type ident field_default:
+        'Elixir.Thrift.Parser.Models.Field':new('$1', '$2', '$3', unwrap('$4'), '$5').
+
+field_required -> required: true.
+field_required -> optional: false.
+field_required -> '$empty': default.
+
+field_default -> '$empty': nil.
+field_default -> '=' literal: '$2'.
+
+typedef_def ->
+    typedef type ident:
+        {typedef, '$2', unwrap('$3')}.
+
+struct_def ->
+    struct ident '{' fields '}':
+        'Elixir.Thrift.Parser.Models.Struct':new(unwrap('$2'), '$4').
+
+service_def ->
+    service ident service_extends '{' functions '}':
+        'Elixir.Thrift.Parser.Models.Service':new(unwrap('$2'), '$5', '$3').
+
+union_def ->
+    union ident '{' fields '}':
+        'Elixir.Thrift.Parser.Models.Union':new(unwrap('$2'), '$4').
+
+service_extends -> '(' extends ident ')': unwrap('$3').
+service_extends -> extends ident: unwrap('$2').
+service_extends -> '$empty': nil.
+
+
+functions -> '$empty': [].
+functions -> function functions: ['$1'] ++ '$2'.
+
+function ->
+    oneway_marker return_type ident '(' fields ')' throws_clause field_sep:
+        'Elixir.Thrift.Parser.Models.Function':new('$1', '$2', unwrap('$3'), '$5', '$7').
+
+oneway_marker -> '$empty': false.
+oneway_marker -> oneway: true.
+
+return_type -> void: void.
+return_type -> type: '$1'.
+
+throws_clause -> '$empty': [].
+throws_clause ->
+    throws '(' fields ')':
+        '$3'.
+
+Erlang code.
+
+unwrap({V, _}) -> V;
+unwrap({_,_,V}) -> V.

--- a/test/lexer_test.exs
+++ b/test/lexer_test.exs
@@ -21,8 +21,8 @@ defmodule LexerTest do
   end
 
   test "symbols" do
-    assert tokenize(";") == [{:symbol, 1, ';'}]
-    assert tokenize("=") == [{:symbol, 1, '='}]
+    assert tokenize(";") == []
+    assert tokenize("=") == [{:=, 1}]
   end
 
   test "keywords" do
@@ -73,39 +73,40 @@ defmodule LexerTest do
   end
 
   test "list literals" do
-    assert tokenize("[]") == [{:symbol, 1, '['}, {:symbol, 1, ']'}]
-    assert tokenize("[1]") == [{:symbol, 1, '['}, {:int, 1, 1}, {:symbol, 1, ']'}]
+    assert tokenize("[]") == [{:"[", 1}, {:"]", 1}]
+    assert tokenize("[1]") == [{:"[", 1}, {:int, 1, 1}, {:"]", 1}]
     assert tokenize("[1,2]") == [
-     {:symbol, 1, '['},
+     {:"[", 1},
      {:int, 1, 1},
-     {:symbol, 1, ','},
+     {:",", 1},
      {:int, 1, 2},
-     {:symbol, 1, ']'}]
+     {:"]", 1}]
   end
 
   test "map literals" do
-    assert tokenize("{}") == [{:symbol, 1, '{'}, {:symbol, 1, '}'}]
+    assert tokenize("{}") == [{:"{", 1}, {:"}", 1}]
     assert tokenize("{'hello':'world'}") == [
-      {:symbol, 1, '{'},
-      {:string, 1, 'hello'}, {:symbol, 1, ':'}, {:string, 1, 'world'},
-      {:symbol, 1, '}'}]
+      {:"{", 1},
+      {:string, 1, 'hello'}, {:":", 1}, {:string, 1, 'world'},
+      {:"}", 1}]
+
     assert tokenize("{'a':1,'b':2}") == [
-      {:symbol, 1, '{'},
-      {:string, 1, 'a'}, {:symbol, 1, ':'}, {:int, 1, 1},
-      {:symbol, 1, ','},
-      {:string, 1, 'b'}, {:symbol, 1, ':'}, {:int, 1, 2},
-      {:symbol, 1, '}'}]
+      {:"{", 1},
+      {:string, 1, 'a'}, {:":", 1}, {:int, 1, 1},
+      {:",", 1},
+      {:string, 1, 'b'}, {:":", 1}, {:int, 1, 2},
+      {:"}", 1}]
   end
 
   test "set literals" do
-    assert tokenize("{}") == [{:symbol, 1, '{'}, {:symbol, 1, '}'}]
-    assert tokenize("{1}") == [{:symbol, 1, '{'}, {:int, 1, 1}, {:symbol, 1, '}'}]
+    assert tokenize("{}") == [{:"{", 1}, {:"}", 1}]
+    assert tokenize("{1}") == [{:"{", 1}, {:int, 1, 1}, {:"}", 1}]
     assert tokenize("{1,2}") == [
-      {:symbol, 1, '{'},
+      {:"{", 1},
       {:int, 1, 1},
-      {:symbol, 1, ','},
+      {:",", 1},
       {:int, 1, 2},
-      {:symbol, 1, '}'}]
+      {:"}", 1}]
   end
 
   test "identifiers" do
@@ -127,15 +128,15 @@ defmodule LexerTest do
       }
     """) == [
       {:enum, 1}, {:ident, 1, 'Operation'},
-      {:symbol, 1, '{'},
-      {:ident, 2, 'ADD'}, {:symbol, 2, '='}, {:int, 2, 1},
-      {:symbol, 2, ','},
-      {:ident, 3, 'SUBTRACT'}, {:symbol, 3, '='}, {:int, 3, 2},
-      {:symbol, 3, ','},
-      {:ident, 4, 'MULTIPLY'}, {:symbol, 4, '='}, {:int, 4, 3},
-      {:symbol, 4, ','},
-      {:ident, 5, 'DIVIDE'}, {:symbol, 5, '='}, {:int, 5, 4},
-      {:symbol, 6, '}'}]
+      {:"{", 1},
+      {:ident, 2, 'ADD'}, {:=, 2}, {:int, 2, 1},
+      {:",", 2},
+      {:ident, 3, 'SUBTRACT'}, {:=, 3}, {:int, 3, 2},
+      {:",", 3},
+      {:ident, 4, 'MULTIPLY'}, {:=, 4}, {:int, 4, 3},
+      {:",", 4},
+      {:ident, 5, 'DIVIDE'}, {:=, 5}, {:int, 5, 4},
+      {:"}", 6}]
   end
 
   test "struct definition" do
@@ -148,16 +149,16 @@ defmodule LexerTest do
       }
     """) == [
       {:struct, 1}, {:ident, 1, 'Work'},
-      {:symbol, 1, '{'},
-      {:int, 2, 1}, {:symbol, 2, ':'}, {:i32, 2}, {:ident, 2, 'num1'}, {:symbol, 2, '='}, {:int, 2, 0},
-      {:symbol, 2, ','},
-      {:int, 3, 2}, {:symbol, 3, ':'}, {:i32, 3}, {:ident, 3, 'num2'},
-      {:symbol, 3, ','},
-      {:int, 4, 3}, {:symbol, 4, ':'}, {:ident, 4, 'Operation'}, {:ident, 4, 'op'},
-      {:symbol, 4, ','},
-      {:int, 5, 4}, {:symbol, 5, ':'}, {:optional, 5}, {:string, 5}, {:ident, 5, 'comment'},
-      {:symbol, 5, ','},
-      {:symbol, 6, '}'}]
+      {:"{", 1},
+      {:int, 2, 1}, {:":", 2}, {:i32, 2}, {:ident, 2, 'num1'}, {:=, 2}, {:int, 2, 0},
+      {:",", 2},
+      {:int, 3, 2}, {:":", 3}, {:i32, 3}, {:ident, 3, 'num2'},
+      {:",", 3},
+      {:int, 4, 3}, {:":", 4}, {:ident, 4, 'Operation'}, {:ident, 4, 'op'},
+      {:",", 4},
+      {:int, 5, 4}, {:":", 5}, {:optional, 5}, {:string, 5}, {:ident, 5, 'comment'},
+      {:",", 5},
+      {:"}", 6}]
   end
 
   test "exception definition" do
@@ -168,11 +169,11 @@ defmodule LexerTest do
       }
     """) == [
       {:exception, 1}, {:ident, 1, 'InvalidOperation'},
-      {:symbol, 1, '{'},
-      {:int, 2, 1}, {:symbol, 2, ':'}, {:i32, 2}, {:ident, 2, 'whatOp'},
-      {:symbol, 2, ','},
-      {:int, 3, 2}, {:symbol, 3, ':'}, {:string, 3}, {:ident, 3, 'why'},
-      {:symbol, 4, '}'}]
+      {:"{", 1},
+      {:int, 2, 1}, {:":", 2}, {:i32, 2}, {:ident, 2, 'whatOp'},
+      {:",", 2},
+      {:int, 3, 2}, {:":", 3}, {:string, 3}, {:ident, 3, 'why'},
+      {:"}", 4}]
   end
 
   test "service definition" do
@@ -184,17 +185,30 @@ defmodule LexerTest do
       }
     """) == [
       {:service, 1}, {:ident, 1, 'Calculator'}, {:extends, 1}, {:ident, 1, 'shared.SharedService'},
-      {:symbol, 1, '{'},
-      {:void, 2}, {:ident, 2, 'ping'}, {:symbol, 2, '('}, {:symbol, 2, ')'},
-      {:symbol, 2, ','},
+      {:"{", 1},
+      {:void, 2}, {:ident, 2, 'ping'}, {:"(", 2}, {:")", 2},
+      {:",", 2},
       {:i32, 3}, {:ident, 3, 'add'},
-        {:symbol, 3, '('},
-          {:int, 3, 1}, {:symbol, 3, ':'}, {:i32, 3}, {:ident, 3, 'num1'},
-          {:symbol, 3, ','},
-          {:int, 3, 2}, {:symbol, 3, ':'}, {:i32, 3}, {:ident, 3, 'num2'},
-        {:symbol, 3, ')'},
-      {:symbol, 3, ','},
-      {:oneway, 4}, {:void, 4}, {:ident, 4, 'zip'}, {:symbol, 4, '('}, {:symbol, 4, ')'},
-      {:symbol, 5, '}'}]
+        {:"(", 3},
+          {:int, 3, 1}, {:":", 3}, {:i32, 3}, {:ident, 3, 'num1'},
+          {:",", 3},
+          {:int, 3, 2}, {:":", 3}, {:i32, 3}, {:ident, 3, 'num2'},
+        {:")", 3},
+      {:",", 3},
+      {:oneway, 4}, {:void, 4}, {:ident, 4, 'zip'}, {:"(", 4}, {:")", 4},
+      {:"}", 5}]
+  end
+
+  test "namespace definition" do
+    assert tokenize("""
+    namespace py foo.bar.baz
+    namespace java com.pinterest.foo.bar.baz
+    namespace * foo.bar
+    """) ==
+      [
+        {:namespace, 1}, {:ident, 1, 'py'}, {:ident, 1, 'foo.bar.baz'},
+        {:namespace, 2}, {:ident, 2, 'java'}, {:ident, 2, 'com.pinterest.foo.bar.baz'},
+        {:namespace, 3}, {:*, 3}, {:ident, 3, 'foo.bar'}
+      ]
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,0 +1,543 @@
+defmodule ParserTest do
+  use ExUnit.Case
+
+  import Thrift.Parser, only: [parse: 1, parse: 2]
+
+  alias Thrift.Parser.Models.Constant
+  alias Thrift.Parser.Models.Exception
+  alias Thrift.Parser.Models.Field
+  alias Thrift.Parser.Models.Function
+  alias Thrift.Parser.Models.Include
+  alias Thrift.Parser.Models.Namespace
+  alias Thrift.Parser.Models.Schema
+  alias Thrift.Parser.Models.Service
+  alias Thrift.Parser.Models.Struct
+  alias Thrift.Parser.Models.StructRef
+  alias Thrift.Parser.Models.TEnum
+  alias Thrift.Parser.Models.Union
+
+  import ExUnit.CaptureIO
+
+  test "parsing comments" do
+    schema = """
+    // a simple C-style comment
+    """
+    |> parse
+
+    assert schema == %Schema{}
+  end
+
+  test "parsing long-comments " do
+    schema = """
+    /* This is a long comment
+    *  that spans many lines
+    *  which means the docs are good
+    *  aren't you happy?
+    */
+    """ |> parse
+
+    assert schema == %Schema{}
+  end
+
+  test "parsing a single include header" do
+    includes = """
+    include "foo.thrift"
+    """ |> parse([:includes])
+
+    assert includes == [%Include{path: "foo.thrift"}]
+  end
+
+  test "parsing namespace headers" do
+    namespaces = """
+    namespace py foo.bar.baz
+    namespace erl foo_bar
+    namespace * bar.baz
+    """
+    |> parse([:namespaces])
+
+    assert namespaces[:py] == %Namespace{name: :py, path: "foo.bar.baz"}
+    assert namespaces[:erl] == %Namespace{name: :erl, path: "foo_bar"}
+    assert namespaces[:*] == %Namespace{name: :*, path: "bar.baz"}
+  end
+
+  test "parsing include headers" do
+    includes = """
+    include "foo.thrift"
+    include "bar.thrift"
+    """
+    |> parse([:includes])
+
+    assert includes == [
+      %Include{path: "foo.thrift"},
+      %Include{path: "bar.thrift"}
+    ]
+  end
+
+  test "parsing a byte constant" do
+    constant = "const i8 BYTE_CONST = 2;"
+    |> parse([:constants, :BYTE_CONST])
+
+    assert constant == %Constant{name: :BYTE_CONST,
+                                 value: 2,
+                                 type: :i8}
+  end
+
+  test "parsing a negative integer constant" do
+    constant = "const i16 NEG_INT_CONST = -281;"
+    |> parse([:constants, :NEG_INT_CONST])
+
+    assert constant == %Constant{name: :NEG_INT_CONST,
+                                 value: -281,
+                                 type: :i16}
+  end
+
+  test "parsing a small int constant" do
+    constant = "const i16 SMALL_INT_CONST = 65535;"
+    |> parse([:constants, :SMALL_INT_CONST])
+
+    assert constant == %Constant{name: :SMALL_INT_CONST,
+                                 value: 65535,
+                                 type: :i16}
+  end
+
+  test "parsing an int constant" do
+    constant = "const i32 INT_CONST = 1234;"
+    |> parse([:constants, :INT_CONST])
+
+    assert constant == %Constant{name: :INT_CONST,
+                                 value: 1234,
+                                 type: :i32}
+  end
+
+  test "parsing a large int constant" do
+    constant = "const i64 LARGE_INT_CONST = 12347437812391;"
+    |> parse([:constants, :LARGE_INT_CONST])
+
+    assert constant == %Constant{name: :LARGE_INT_CONST,
+                                 value: 12347437812391,
+                                 type: :i64}
+  end
+
+  test "parsing a double constant" do
+    constant = "const double DOUBLE_CONST = 123.4"
+    |> parse([:constants, :DOUBLE_CONST])
+
+    assert constant == %Constant{name: :DOUBLE_CONST,
+                                 value: 123.4,
+                                 type: :double}
+  end
+
+  test "parsing a string constant" do
+    constant = "const string STRING_CONST = \"hi\""
+    |> parse([:constants, :STRING_CONST])
+
+    assert constant == %Constant{name: :STRING_CONST,
+                                 value: "hi",
+                                 type: :string}
+  end
+
+  test "parsing a set constant" do
+    constant = "const set<string> SET_CONST = {\"hello\", \"bye\"}"
+    |> parse([:constants, :SET_CONST])
+
+
+    assert constant == %Constant{name: :SET_CONST,
+                                 value: MapSet.new(["hello", "bye"]),
+                                 type: {:set, :string}}
+  end
+
+  test "parsing a set int constant" do
+    constant = "const set<i32> SET_INT_CONST = {1, 3}"
+    |> parse([:constants, :SET_INT_CONST])
+
+    assert constant == %Constant{name: :SET_INT_CONST,
+                                 value: MapSet.new([1, 3]),
+                                 type: {:set, :i32}}
+  end
+
+  test "parsing a map constant" do
+    constant = "const map<string, i32> MAP_CONST = {\"hello\": 1, \"world\": 2};"
+    |> parse([:constants, :MAP_CONST])
+
+
+    assert constant == %Constant{name: :MAP_CONST,
+                                 value: %{"world" => 2, "hello" => 1},
+                                 type: {:map, {:string, :i32}}}
+  end
+
+  test "parsing a list constant" do
+    constant = "const list<i32> LIST_CONST = [5, 6, 7, 8]"
+    |> parse([:constants, :LIST_CONST])
+
+    assert constant == %Constant{name: :LIST_CONST,
+                                 value: [5, 6, 7, 8],
+                                 type: {:list, :i32}}
+  end
+
+  test "parsing an enum" do
+    user_status = """
+    enum UserStatus {
+      ACTIVE,
+      INACTIVE,
+      BANNED = 6,
+      EVIL = 0x20
+    }
+    """
+    |> parse([:enums, :UserStatus])
+
+    assert user_status == %TEnum{name: :UserStatus,
+                                 values: [ACTIVE: 1, INACTIVE: 2, BANNED: 6, EVIL: 32]}
+  end
+
+  test "parsing an exception" do
+    program = """
+    exception ApplicationException {
+      1: string message,
+      2: required i32 count,
+      3: optional string reason
+      optional string other;
+      optional string fixed = "foo"
+    }
+    """
+
+    warnings = capture_io(fn ->
+      exc = parse(program, [:exceptions, :ApplicationException])
+
+      assert exc == %Exception{
+        name: :ApplicationException,
+        fields: [
+          %Field{id: 1, name: :message, type: :string},
+          %Field{id: 2, name: :count, type: :i32, required: true},
+          %Field{id: 3, name: :reason, type: :string, required: false},
+          %Field{id: 4, name: :other, type: :string, required: false},
+          %Field{id: 5, name: :fixed, type: :string, required: false, default: "foo"}
+        ]}
+    end)
+    |> String.split("\n")
+    |> Enum.map(&String.slice(&1, (5..-5)))
+
+    warning_1 = "Warning: id not set for field 'ApplicationException.other'."
+    warning_2 = "Warning: id not set for field 'ApplicationException.fixed'."
+
+    assert warning_1 in warnings
+    assert warning_2 in warnings
+  end
+
+  test "an exception with duplicate ids" do
+    program = """
+    exception BadEx {
+     1: optional string bad,
+     1: optional string evil;
+    }
+    """
+
+    expected_error = "Error: BadEx.evil, BadEx.bad share field number 1."
+    assert_raise RuntimeError, expected_error, fn ->
+      parse(program)
+    end
+  end
+
+  test "parsing a typedef" do
+    typedefs = """
+    typedef i64 id
+    typedef string json
+    typedef list<string> string_list
+    """
+    |> parse([:typedefs])
+
+    assert typedefs[:id] == :i64
+    assert typedefs[:string_list] == {:list, :string}
+  end
+
+  test "parsing a struct with an int" do
+    s = """
+    struct MyStruct {
+      1: optional string name;
+    }
+    """
+    |> parse([:structs, :MyStruct])
+
+    assert s == %Struct{
+      name: :MyStruct,
+      fields: [
+        %Field{id: 1, name: :name, type: :string, required: false}
+      ]}
+  end
+
+  test "parsing a struct with a typedef" do
+    s = """
+    typedef i64 id
+
+    struct User {
+      1: required id user_id,
+      2: required string username
+    }
+    """ |> parse([:structs, :User])
+
+    assert s.fields == [
+      %Field{id: 1, name: :user_id, required: true, type: %StructRef{referenced_type: :id}},
+      %Field{id: 2, name: :username, required: true, type: :string}
+    ]
+  end
+
+  test "parsing a struct with optional things removed" do
+    struct_def = """
+    struct Optionals {
+      string name
+      i32 count,
+      i64 long_thing = 12345
+      optional list<i32> optional_list,
+    }
+    """
+
+    warnings = capture_io(fn ->
+      s = parse(struct_def, [:structs, :Optionals])
+
+      assert s == %Struct{
+        name: :Optionals,
+        fields: [
+          %Field{id: 1, name: :name, type: :string, required: :default},
+          %Field{id: 2, name: :count, type: :i32, required: :default},
+          %Field{id: 3, name: :long_thing, type: :i64, required: :default, default: 12345},
+          %Field{id: 4, name: :optional_list, type: {:list, :i32}, required: false}
+        ]
+      }
+    end)
+    |> String.split("\n")
+    |> Enum.map(&String.slice(&1, 5..-5)) # get rid of the terminal chars
+
+    [:name, :count, :long_thing, :optional_list]
+    |> Enum.each(fn(field_name) ->
+
+      warning = "Warning: id not set for field 'Optionals.#{field_name}'."
+      assert warning in warnings
+    end)
+  end
+
+  test "when default ids conflict with explicit ids" do
+
+    assert_raise RuntimeError, fn ->
+      capture_io fn ->
+        """
+        struct BadFields {
+          required i32 first,
+          1: optional i64 other
+        }
+        """ |> parse
+      end
+    end
+  end
+
+  test "when a struct has another struct as a member" do
+    user = """
+    struct Name {
+      1: string first_name,
+      2: string last_name
+    }
+
+    struct User {
+       1: i64 id,
+       2: Name name,
+    }
+    """ |> parse([:structs, :User])
+    assert user == %Struct{
+      name: :User,
+      fields: [
+        %Field{id: 1, type: :i64, name: :id},
+        %Field{id: 2, type: %StructRef{referenced_type: :Name}, name: :name}
+      ]
+    }
+  end
+
+  test "parsing a union definition" do
+    union = """
+    union Highlander {
+      1: i32 connery,
+      2: i64 lambert
+    }
+    """
+    |> parse([:unions, :Highlander])
+
+    assert union == %Union{
+      name: :Highlander,
+      fields: [
+        %Field{id: 1, name: :connery, type: :i32, required: false},
+        %Field{id: 2, name: :lambert, type: :i64, required: false},
+      ]
+    }
+  end
+
+  test "a union definition makes sure its field ids aren't repeated" do
+    capture_io fn ->
+      assert_raise RuntimeError, fn ->
+      """
+        union Highlander {
+          i32 connery,
+          1: i64 lambert
+        }
+      """
+      |> parse
+      end
+
+    end
+  end
+
+  test "defining a simple service" do
+    service = """
+    service MyService {
+      void hi()
+    }
+    """
+    |> parse([:services, :MyService])
+
+
+    assert service == %Service{
+      name: :MyService,
+      functions: [
+        %Function{name: :hi, return_type: :void, params: []}
+      ]
+    }
+  end
+
+  test "defining a service with a complex return type and params" do
+    service = """
+    struct User {
+    }
+
+    service MyService {
+       map<string, i64> usernames_to_ids(1: User user)
+    }
+    """
+    |> parse([:services, :MyService])
+
+    assert service == %Service{
+      name: :MyService,
+      functions: [
+        %Function{name: :usernames_to_ids, oneway: false, return_type: {:map, {:string, :i64}},
+                  params: [%Field{id: 1, name: :user, type: %StructRef{referenced_type: :User}}]
+                 }
+      ]
+    }
+  end
+
+  test "a oneway function in a service" do
+    service = """
+    service OneWay {
+      oneway void fireAndForget(1: i64 value);
+    }
+    """
+    |> parse([:services, :OneWay])
+
+    assert service == %Service{
+      name: :OneWay,
+      functions: [
+        %Function{
+          name: :fireAndForget, oneway: true, return_type: :void,
+          params: [
+            %Field{id: 1, name: :value, type: :i64}
+          ]
+        }
+      ]
+    }
+  end
+
+  test "a service that throws exceptions" do
+    service = """
+    exception ServiceException {
+      1: i32 error_code = 0,
+      2: string reason = "Unknown"
+    }
+
+    service Thrower {
+       oneway void blowup() throws (1: ServiceException svc)
+    }
+    """
+    |> parse([:services, :Thrower])
+
+    [function] = service.functions
+    assert function.exceptions == [
+      %Field{id: 1, name: :svc, type: %StructRef{referenced_type: :ServiceException}}
+    ]
+  end
+
+  test "a service with several functions" do
+    code = """
+    struct User {
+      1: i64 id,
+      2: string username
+    }
+
+    exception ServiceException {
+      1: string message
+      2: i32 code
+    }
+
+    service MultipleFns {
+       void ping(),
+       oneway void update(1: i64 user_id, string field, string value),
+       map<i64, User> get_users(1: set<i64> user_ids) throws (1: ServiceException svc)
+    }
+    """
+    capture_io fn ->
+      service = parse(code, [:services, :MultipleFns])
+
+      [ping, update, get_users] = service.functions
+
+      assert ping == %Function{name: :ping}
+      assert update == %Function{
+        oneway: true,
+        name: :update,
+        params: [
+          %Field{id: 1, name: :user_id, type: :i64},
+          %Field{id: 2, name: :field, type: :string},
+          %Field{id: 3, name: :value, type: :string}
+        ]
+      }
+      assert get_users == %Function{
+        name: :get_users,
+        exceptions: [
+          %Field{id: 1, name: :svc, type: %StructRef{referenced_type: :ServiceException}}
+        ],
+        params: [
+          %Field{id: 1, name: :user_ids, type: {:set, :i64}},
+        ],
+        return_type: {:map, {:i64, %StructRef{referenced_type: :User}}}
+      }
+    end
+  end
+
+  test "a service extends another" do
+    services = """
+    service Pinger {
+      boolean ping()
+    }
+
+    service Extender (extends Pinger)  {
+      boolean is_ready()
+    }
+
+    service OtherExtender extends Pinger {
+      boolean has_failed()
+    }
+    """
+    |> parse([:services])
+
+    pinger = services[:Extender]
+    other  = services[:OtherExtender]
+
+    assert pinger.extends == :Pinger
+    assert other.extends == :Pinger
+  end
+
+  test "parsing a real thrift file" do
+    # just make sure we don't blow up on parse and can parse
+    # complex thrift files.
+
+    File.read!("./test/fixtures/app/thrift/tutorial.thrift")
+    |> parse
+
+    File.read!("./test/fixtures/app/thrift/shared.thrift")
+    |> parse
+  end
+
+end


### PR DESCRIPTION
This PR introduces a parser based on @jparise's lexer. The parser
runs on thrift files and produces a set of Program models. The
intention is to be able to give Elixir full-fledged thrift support
and a better (and faster) implementation.

@jparise @stemmler 