### PR TITLE
Simplify the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     - libssl-dev
     - pkg-config
 before_install:
-  - git submodule update --init
   - make install-thrift
   - export PATH=$HOME/bin:$PATH
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ before_install:
   - git submodule update --init
   - make install-thrift
   - export PATH=$HOME/bin:$PATH
-before_script:
-  - mix local.hex --force
-script:
-  - MIX_ENV=test mix do deps.get, compile
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ addons:
     - libssl-dev
     - pkg-config
 before_install:
+  - git submodule update --init
   - make install-thrift
   - export PATH=$HOME/bin:$PATH
 before_script:
   - mix local.hex --force
 script:
-  - git submodule init
-  - git submodule update
   - MIX_ENV=test mix do deps.get, compile
 after_script:
   - MIX_ENV=test mix coveralls.travis


### PR DESCRIPTION
Travis already updates our git submodules automatically, and the default
`install` and `script` commands do all of the things we need them to do.