### PR TITLE
Require at least Elixir 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-  - 1.1.1
   - 1.2.6
 otp_release:
   - 18.2.1

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Thrift.Mixfile do
   def project do
     [app: :thrift,
      version: @version,
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      deps: deps,
 
      # Build Environment


### PR DESCRIPTION
With today's release of Elixir 1.3, now is a good time to drop compatibility
with much older releases. This also lets us use some of the nicer language
features introduced in Elixir 1.2, like the multi-alias syntax.