### PR TITLE
Include OTP 18.3 and 19.0 in the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: elixir
 elixir:
   - 1.2.6
-  - 1.3.1
+  - 1.3.2
 otp_release:
-  - 18.2.1
+  - 18.2
+  - 18.3
+  - 19.0
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Also bump Elixir 1.3.1 to 1.3.2.