### PR TITLE
Full test coverage for Mix.Tasks.Compile.Thrift

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.Compile.Thrift do
   end
 
   defp get_thrift_version(exec) do
-    case System.cmd(exec, ~w[-version]) do
+    case System.cmd(exec, ~w[-version], stderr_to_stdout: true) do
       {s, 0} -> hd(Regex.run(~r/\b(\d+\.\d+\.\d+)\b/, s, capture: :first) || [])
       {_, e} -> Mix.raise "Failed to execute `#{exec} -version` (error #{e})"
     end
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Compile.Thrift do
 
   defp generate(exec, options, thrift_file) do
     args = options ++ [thrift_file]
-    case System.cmd(exec, args) do
+    case System.cmd(exec, args, stderr_to_stdout: true) do
       {_, 0} -> Mix.shell.info "Compiled #{thrift_file}"
       {_, e} -> Mix.shell.error "Failed to compile #{thrift_file} (error #{e})"
     end

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -52,10 +52,20 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
-  test "specifying an empty :thrift_files list " do
+  test "specifying an empty :thrift_files list" do
     in_fixture fn ->
       with_project_config [thrift_files: []], fn ->
         assert capture_io(fn -> run([]) end) == ""
+      end
+    end
+  end
+
+  test "specifying a non-existent Thrift file" do
+    in_fixture fn ->
+      with_project_config [thrift_files: ~w("missing.thrift")], fn ->
+        capture_io fn ->
+          assert capture_io(:stderr, fn -> run([]) end) =~ "Failed to compile"
+        end
       end
     end
   end
@@ -64,6 +74,16 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     in_fixture fn ->
       with_project_config [thrift_executable: "nonexistentthrift"], fn ->
         assert_raise Mix.Error, "`nonexistentthrift` not found in the current path", fn ->
+          run([])
+        end
+      end
+    end
+  end
+
+  test "attempting to use a broken Thrift executable" do
+    in_fixture fn ->
+      with_project_config [thrift_executable: "mix", thrift_version: "0.0.0"], fn ->
+        assert_raise Mix.Error, ~r/Failed to execute/, fn ->
           run([])
         end
       end


### PR DESCRIPTION
Add test coverage for the last two remaining error cases. This brings
this module's unit test coverage up to 100%.

This also includes one functional change: we now redirect :stderr output
to :stdout so we can more consistently capture and display output from
the Thrift compiler executable.