### PR TITLE
Allow $THRIFT to specify the `thrift` executable

### DIFF
--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -4,6 +4,7 @@ defmodule App.Mixfile do
   def project do
     [app: :app,
      version: "1.0.0",
+     thrift_executable: System.get_env("THRIFT") || "thrift",
      thrift_files: Mix.Utils.extract_files(["thrift"], [:thrift])]
   end
 end


### PR DESCRIPTION
This makes it easy to run the unit tests against alternate Thrift
compiler executables.