### PR TITLE
Set $THRIFT to the full `docker run ...` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: required
 group: edge
 services: docker
 env:
-  - THRIFT=${TRAVIS_BUILD_DIR}/ci/thrift-docker
+  - THRIFT="docker run -v ${TRAVIS_BUILD_DIR}:/thrift-elixir -w /thrift-elixir/test/fixtures/app --rm thrift:0.9.3 thrift"
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/ci/thrift-docker
+++ b/ci/thrift-docker
@@ -1,3 +1,0 @@
-#!/bin/bash
-rootdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-docker run -v ${rootdir}:/thrift-elixir -w /thrift-elixir/test/fixtures/app --rm thrift:0.9.3 thrift $*


### PR DESCRIPTION
This lets us drop the ci/thrift-docker helper script.