### PR TITLE
File Parser / Resolver

### DIFF
--- a/lib/parser/file_group.ex
+++ b/lib/parser/file_group.ex
@@ -12,8 +12,6 @@ defmodule Thrift.Parser.FileGroup do
     Schema,
   }
 
-  defdelegate fix_refs(), to: Resolver
-
   @type t :: %FileGroup{
     parsed_files: %{FileRef.thrift_include => %ParsedFile{}},
     schemas: %{FileRef.thrift_include => %Schema{}}}

--- a/lib/parser/file_group.ex
+++ b/lib/parser/file_group.ex
@@ -1,4 +1,10 @@
 defmodule Thrift.Parser.FileGroup do
+  @moduledoc """
+  Represents a group of parsed files. When you parse a file, it might include other thrift files.
+  These files are in turn accumulated and parsed and added to this module.
+  Additionally, this module allows resolution of the names of Structs / Enums / Unions etc across
+  files.
+  """
   alias Thrift.Parser.{
     FileGroup,
     FileRef,

--- a/lib/parser/file_group.ex
+++ b/lib/parser/file_group.ex
@@ -1,0 +1,63 @@
+defmodule Thrift.Parser.FileGroup do
+  alias Thrift.Parser.{
+    FileGroup,
+    FileRef,
+    Resolver,
+    ParsedFile
+  }
+
+  alias Thrift.Parser.Models.{
+    Field,
+    StructRef,
+    Schema,
+  }
+
+  defdelegate fix_refs(), to: Resolver
+
+  @type t :: %FileGroup{
+    parsed_files: %{FileRef.thrift_include => %ParsedFile{}},
+    schemas: %{FileRef.thrift_include => %Schema{}}}
+
+  defstruct parsed_files: %{}, schemas: %{}, resolutions: %{}
+
+  def add(file_group, parsed_file) do
+    file_group = add_includes(file_group, parsed_file)
+    new_parsed_files = Map.put(file_group.parsed_files, parsed_file.name, parsed_file)
+    new_schemas = Map.put(file_group.schemas, parsed_file.name, parsed_file.schema)
+
+    Resolver.add(parsed_file)
+    %__MODULE__{file_group |
+                parsed_files: new_parsed_files,
+                schemas: new_schemas}
+  end
+
+  def add_includes(group=%__MODULE__{},
+                   %ParsedFile{schema: schema, file_ref: file_ref}) do
+
+    Enum.reduce(schema.includes, group, fn(include, file_group) ->
+      parsed_file = file_ref.path
+      |> Path.dirname
+      |> Path.join(include.path)
+      |> FileRef.new
+      |> ParsedFile.new
+      add(file_group, parsed_file)
+    end)
+  end
+
+  def resolve(%FileGroup{}=group, %Field{type: %StructRef{}=ref}=field) do
+    %Field{field | type: resolve(group, ref)}
+  end
+
+  def resolve(%FileGroup{resolutions: resolutions}, %StructRef{referenced_type: type_name}) do
+    resolutions[type_name]
+  end
+
+  def resolve(%FileGroup{resolutions: resolutions}, path) when is_atom(path) do
+    resolutions[path]
+  end
+
+  def resolve(_, other) do
+    other
+  end
+
+end

--- a/lib/parser/file_ref.ex
+++ b/lib/parser/file_ref.ex
@@ -1,0 +1,18 @@
+defmodule Thrift.Parser.FileRef do
+  @type thrift_include :: String.t
+  @type t :: %__MODULE__{path: String.t, include_name: String.t, contents: String.t}
+  defstruct path: nil, include_name: nil, contents: nil
+
+  def new(path) do
+    thrift_file = """
+    __file__ "#{path}"
+
+    #{File.read!(path)}
+    """
+    %__MODULE__{path: path, include_name: include_name(path), contents: thrift_file}
+  end
+
+  def include_name(path) do
+    Path.basename(path, ".thrift")
+  end
+end

--- a/lib/parser/file_ref.ex
+++ b/lib/parser/file_ref.ex
@@ -4,6 +4,9 @@ defmodule Thrift.Parser.FileRef do
   defstruct path: nil, include_name: nil, contents: nil
 
   def new(path) do
+    # We include the __file__ here to hack around the fact that leex and yeec don't
+    # operate on files and lose the file info. This is relevant because the filename is
+    # turned into the thrift module, and is necessary for resolution.
     thrift_file = File.read!(path) <> "\n__file__ \"#{path}\""
     %__MODULE__{path: path, include_name: include_name(path), contents: thrift_file}
   end

--- a/lib/parser/file_ref.ex
+++ b/lib/parser/file_ref.ex
@@ -4,7 +4,7 @@ defmodule Thrift.Parser.FileRef do
   defstruct path: nil, include_name: nil, contents: nil
 
   def new(path) do
-    # We include the __file__ here to hack around the fact that leex and yeec don't
+    # We include the __file__ here to hack around the fact that leex and yecc don't
     # operate on files and lose the file info. This is relevant because the filename is
     # turned into the thrift module, and is necessary for resolution.
     thrift_file = File.read!(path) <> "\n__file__ \"#{path}\""

--- a/lib/parser/file_ref.ex
+++ b/lib/parser/file_ref.ex
@@ -4,11 +4,7 @@ defmodule Thrift.Parser.FileRef do
   defstruct path: nil, include_name: nil, contents: nil
 
   def new(path) do
-    thrift_file = """
-    __file__ "#{path}"
-
-    #{File.read!(path)}
-    """
+    thrift_file = File.read!(path) <> "\n__file__ \"#{path}\""
     %__MODULE__{path: path, include_name: include_name(path), contents: thrift_file}
   end
 

--- a/lib/parser/models.ex
+++ b/lib/parser/models.ex
@@ -526,34 +526,34 @@ end
       end
 
       defp merge(schema, %TEnum{} = enum) do
-        %Schema{schema | enums: Map.put(schema.enums, enum.name, update_name(schema, enum))}
+        %Schema{schema | enums: Map.put(schema.enums, enum.name, canonicalize_name(schema, enum))}
       end
 
       defp merge(schema, %Exception{} = exc) do
-        %Schema{schema | exceptions: Map.put(schema.exceptions, exc.name, update_name(schema, exc))}
+        %Schema{schema | exceptions: Map.put(schema.exceptions, exc.name, canonicalize_name(schema, exc))}
       end
 
       defp merge(schema, %Struct{} = s) do
-        %Schema{schema | structs: Map.put(schema.structs, s.name, update_name(schema, s))}
+        %Schema{schema | structs: Map.put(schema.structs, s.name, canonicalize_name(schema, s))}
       end
 
       defp merge(schema, %Union{} = union) do
-        %Schema{schema | unions: Map.put(schema.unions, union.name, update_name(schema, union))}
+        %Schema{schema | unions: Map.put(schema.unions, union.name, canonicalize_name(schema, union))}
       end
 
       defp merge(schema, %Service{} = service) do
-        %Schema{schema | services: Map.put(schema.services, service.name, update_name(schema, service))}
+        %Schema{schema | services: Map.put(schema.services, service.name, canonicalize_name(schema, service))}
       end
 
       defp merge(schema, {:typedef, actual_type, type_alias}) do
         %Schema{schema | typedefs: Map.put(schema.typedefs, atomify(type_alias), actual_type)}
       end
 
-      defp update_name(%{module: nil}, model) do
+      defp canonicalize_name(%{module: nil}, model) do
         model
       end
 
-      defp update_name(schema, %{name: name}=model) do
+      defp canonicalize_name(schema, %{name: name}=model) do
         %{model | name: :"#{schema.module}.#{name}"}
       end
     end

--- a/lib/parser/models.ex
+++ b/lib/parser/models.ex
@@ -424,7 +424,7 @@ end
       """
 
       @type t :: %Service{name: String.t, extends: String.t, functions: %{atom => %Function{}}}
-      defstruct name: nil, extends: nil, functions: {}
+      defstruct name: nil, extends: nil, functions: %{}
 
       import Thrift.Parser.Conversions
 
@@ -555,10 +555,6 @@ end
 
       defp update_name(schema, %{name: name}=model) do
         %{model | name: :"#{schema.module}.#{name}"}
-      end
-
-      defp update_name(_schema, model) do
-        model
       end
     end
 

--- a/lib/parser/parsed_file.ex
+++ b/lib/parser/parsed_file.ex
@@ -1,0 +1,15 @@
+defmodule Thrift.Parser.ParsedFile do
+  alias Thrift.Parser.Models.Schema
+  alias Thrift.Parser
+  alias Thrift.Parser.FileRef
+
+  @type t :: %__MODULE__{file_ref: %FileRef{}, schema: %Schema{}, name: String.t}
+  defstruct file_ref: nil, schema: nil, name: nil
+
+  def new(file_ref=%FileRef{}) do
+    %__MODULE__{file_ref: file_ref,
+                schema: Parser.parse(file_ref.contents),
+                name: FileRef.include_name(file_ref.path)
+               }
+  end
+end

--- a/lib/parser/parser.ex
+++ b/lib/parser/parser.ex
@@ -5,7 +5,7 @@ defmodule Thrift.Parser do
 
   @type path_element :: String.t | atom
 
-  alias Thrift.Parser.Models
+  alias Thrift.Parser.{FileGroup, FileRef, Models, ParsedFile, Resolver}
   alias Thrift.Parser.Models.Schema
 
   @doc """
@@ -44,5 +44,25 @@ defmodule Thrift.Parser do
       (part, %{} = next) ->
         Map.get(next, part)
     end)
+  end
+
+  @doc """
+  Takes a directory that contains thrift files and a list
+  of the contents of each and runs them through the thrift parser
+  """
+  @spec parse_file(Path.t) :: %FileGroup{}
+  def parse_file(file_path) do
+    Resolver.start_link()
+    parsed_file = file_path
+    |> FileRef.new
+    |> ParsedFile.new
+
+    file_group = %FileGroup{}
+    |> FileGroup.add(parsed_file)
+
+    resolutions = Resolver.get()
+    Resolver.stop()
+
+    %{file_group | resolutions: resolutions}
   end
 end

--- a/lib/parser/parser.ex
+++ b/lib/parser/parser.ex
@@ -47,8 +47,8 @@ defmodule Thrift.Parser do
   end
 
   @doc """
-  Takes a directory that contains thrift files and a list
-  of the contents of each and runs them through the thrift parser
+  Takes a path to a file and parses it, adding any includes to the
+  parsed results.
   """
   @spec parse_file(Path.t) :: %FileGroup{}
   def parse_file(file_path) do

--- a/lib/parser/resolver.ex
+++ b/lib/parser/resolver.ex
@@ -1,4 +1,10 @@
 defmodule Thrift.Parser.Resolver do
+  @moduledoc """
+  A resolver for references.
+  During file parsing, all new generated thrift concepts flow through this resolver
+  and are added to its global database of names. At the end, the database is dumped into
+  the FileGroup so it can resolve references.
+  """
   alias Thrift.Parser.ParsedFile
   alias Thrift.Parser.Models.StructRef
 

--- a/lib/parser/resolver.ex
+++ b/lib/parser/resolver.ex
@@ -1,0 +1,66 @@
+defmodule Thrift.Parser.Resolver do
+  alias Thrift.Parser.ParsedFile
+  alias Thrift.Parser.Models.{
+    Field,
+    StructRef
+  }
+
+  def start_link do
+    Agent.start_link(&Map.new/0, name: __MODULE__)
+  end
+
+  def stop do
+    Agent.stop(__MODULE__)
+  end
+
+  def print do
+    Agent.get(__MODULE__, &IO.inspect(&1))
+  end
+
+  def add(f=%ParsedFile{}) do
+    Agent.update(__MODULE__, fn(state) ->
+      state
+      |> update(f.name, f.schema.services)
+      |> update(f.name, f.schema.structs)
+      |> update(f.name, f.schema.exceptions)
+      |> update(f.name, f.schema.unions)
+      |> update(f.name, f.schema.enums)
+    end)
+  end
+
+  def get do
+    Agent.get(__MODULE__, &(&1))
+  end
+
+  def resolve(%{fields: field_list}) do
+    field_list
+    |> Enum.map(&resolve/1)
+  end
+
+  def resolve(%Field{type: %StructRef{}=ref}) do
+    resolve(ref)
+  end
+
+  def resolve(%StructRef{referenced_type: type_name}) do
+    __MODULE__
+    |> Agent.get(&(&1[type_name]))
+    |> resolve
+  end
+
+  def resolve(path) when is_atom(path) do
+    Agent.get(__MODULE__, &(&1[path]))
+  end
+
+  def resolve(other) do
+    other
+  end
+
+  defp update(%{}=state, include_name, local_mappings=%{}) do
+    new_mappings = local_mappings
+    |> Map.new(fn {name, val} ->
+      {:"#{include_name}.#{name}", Map.put(val, :name, :"#{include_name}.#{name}")}
+    end)
+
+    Map.merge(state, new_mappings)
+  end
+end

--- a/lib/parser/resolver.ex
+++ b/lib/parser/resolver.ex
@@ -1,9 +1,6 @@
 defmodule Thrift.Parser.Resolver do
   alias Thrift.Parser.ParsedFile
-  alias Thrift.Parser.Models.{
-    Field,
-    StructRef
-  }
+  alias Thrift.Parser.Models.StructRef
 
   def start_link do
     Agent.start_link(&Map.new/0, name: __MODULE__)
@@ -11,10 +8,6 @@ defmodule Thrift.Parser.Resolver do
 
   def stop do
     Agent.stop(__MODULE__)
-  end
-
-  def print do
-    Agent.get(__MODULE__, &IO.inspect(&1))
   end
 
   def add(f=%ParsedFile{}) do
@@ -32,30 +25,7 @@ defmodule Thrift.Parser.Resolver do
     Agent.get(__MODULE__, &(&1))
   end
 
-  def resolve(%{fields: field_list}) do
-    field_list
-    |> Enum.map(&resolve/1)
-  end
-
-  def resolve(%Field{type: %StructRef{}=ref}) do
-    resolve(ref)
-  end
-
-  def resolve(%StructRef{referenced_type: type_name}) do
-    __MODULE__
-    |> Agent.get(&(&1[type_name]))
-    |> resolve
-  end
-
-  def resolve(path) when is_atom(path) do
-    Agent.get(__MODULE__, &(&1[path]))
-  end
-
-  def resolve(other) do
-    other
-  end
-
-  defp update(%{}=state, include_name, local_mappings=%{}) do
+  defp update(%{}=state, include_name, %{}=local_mappings) do
     new_mappings = local_mappings
     |> Map.new(fn {name, val} ->
       {:"#{include_name}.#{name}", Map.put(val, :name, :"#{include_name}.#{name}")}

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -47,6 +47,8 @@ Rules.
 {LT}            : {token, {'<', TokenLine}}.
 {COMMA}         : {token, {',', TokenLine}}.
 {COLON}         : {token, {':', TokenLine}}.
+
+__file__        : {token, {file, TokenLine}}.
 namespace       : {token, {namespace, TokenLine}}.
 include         : {token, {include, TokenLine}}.
 

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -1,6 +1,7 @@
 
 Nonterminals
 schema
+file_def
 headers header
 definitions definition
 namespace_def constant_def include_def
@@ -22,6 +23,7 @@ throws_clause.
 
 Terminals
 '*' '{' '}' '[' ']' '(' ')' '=' '>' '<' ',' ':'
+file
 namespace
 include
 ident
@@ -58,8 +60,12 @@ throws.
 Rootsymbol schema.
 
 schema ->
-    headers definitions:
-        'Elixir.Thrift.Parser.Models.Schema':new('$1', '$2').
+    file_def headers definitions:
+        'Elixir.Thrift.Parser.Models.Schema':new('$1', '$2', '$3').
+
+file_def -> '$empty': nil.
+file_def ->
+    file string: 'Elixir.List':to_string(unwrap('$2')).
 
 headers -> '$empty': [].
 headers -> header headers: ['$1'] ++ '$2'.

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -60,8 +60,8 @@ throws.
 Rootsymbol schema.
 
 schema ->
-    file_def headers definitions:
-        'Elixir.Thrift.Parser.Models.Schema':new('$1', '$2', '$3').
+    headers definitions file_def:
+        'Elixir.Thrift.Parser.Models.Schema':new('$3', '$1', '$2').
 
 file_def -> '$empty': nil.
 file_def ->

--- a/test/fixtures/app/thrift/shared.thrift
+++ b/test/fixtures/app/thrift/shared.thrift
@@ -35,6 +35,11 @@ struct SharedStruct {
   2: string value
 }
 
+exception SharedException {
+  1: string message,
+  2: i32 code
+}
+
 service SharedService {
   SharedStruct getStruct(1: i32 key)
 }

--- a/test/fixtures/app/thrift/tutorial.thrift
+++ b/test/fixtures/app/thrift/tutorial.thrift
@@ -144,6 +144,7 @@ service Calculator extends shared.SharedService {
     */
    oneway void zip()
 
+   shared.SharedStruct sharingTest(1: shared.SharedStruct s) throws (1: shared.SharedException ex)
 }
 
 /**

--- a/test/parser/resolver_test.exs
+++ b/test/parser/resolver_test.exs
@@ -1,0 +1,175 @@
+defmodule ResolverTest do
+  use ExUnit.Case
+  @thrift_dir "test/fixtures/app/thrift"
+
+  alias Thrift.Parser.FileGroup
+  alias Thrift.Parser.Models.{
+    TEnum,
+    Service,
+    Struct,
+    Union
+  }
+
+  use ThriftTestHelpers
+
+  test "it should be able resolve Struct Refs" do
+    with_thrift_files([
+      "core/shared.thrift": """
+      struct User {
+        1: i64 id,
+        2: string username,
+        3: string email
+      }
+      """,
+      "utils.thrift": """
+       include "core/shared.thrift"
+       service Users {
+         shared.User find_by_id(1: i64 user_id);
+       }
+       """, as: :file_group, parse: "utils.thrift"]) do
+
+      return_ref = file_group.schemas["utils"].services[:"Users"].functions[:find_by_id].return_type
+
+      refute is_nil(return_ref)
+
+      resolved_struct = FileGroup.resolve(file_group, return_ref)
+
+      assert resolved_struct == file_group.schemas["shared"].structs[:User]
+    end
+  end
+
+  test "it should be able to resolve services" do
+
+    with_thrift_files(
+      "core/shared.thrift": """
+      service Shared {
+        bool get_shared(1: i64 id);
+      }
+      """,
+
+      "extendo.thrift": """
+      include "core/shared.thrift"
+
+      service Extend extends shared.Shared {
+        i64 get_extendo_value();
+      }
+      """, parse: "extendo.thrift") do
+
+      shared = FileGroup.resolve(file_group, :"shared.Shared")
+
+      assert %Service{} = shared
+      assert :get_shared in Map.keys(shared.functions)
+
+      extendo = FileGroup.resolve(file_group, :"extendo.Extend")
+      assert %Service{} = extendo
+      assert :get_extendo_value in Map.keys(extendo.functions)
+    end
+
+  end
+
+  test "it should handle following includes through several files" do
+    with_thrift_files(
+      "core/states.thrift": """
+      enum UserState {
+        ACTIVE,
+        LAPSED,
+        DISABLED
+      }
+      """,
+
+      "core/models.thrift": """
+      include "states.thrift"
+
+      exception UserNotFound {
+       1: i64 user_id;
+      }
+
+      struct User {
+        1: i64 user_id,
+        2: string username,
+        3: string first_name,
+        4: string last_name,
+        5: states.UserState state;
+      }
+      """,
+
+      "user_service/user_service.thrift": """
+      include "../core/models.thrift"
+      service UserService {
+        models.User get_by_id(1: i64 user_id) throws (1: models.UserNotFound unf),
+        void set_username(1: models.User user, 2: string username);
+      }
+      """, parse: "user_service/user_service.thrift") do
+
+      user_state = FileGroup.resolve(file_group, :"states.UserState")
+
+      assert %TEnum{values: [ACTIVE: 1, LAPSED: 2, DISABLED: 3]} = user_state
+      assert user_state.name == :"states.UserState"
+    end
+
+  end
+
+  test "it should be able to resolve complex includes" do
+    with_thrift_files(
+      "includes/enums.thrift": """
+      enum JobStatus {
+        STOPPED,
+        RUNNING,
+        FAILED
+      }
+      """,
+
+      "includes/unions.thrift": """
+      include "structs.thrift"
+
+      union JobSubject {
+        1: structs.User user,
+        2: structs.System sys;
+      }
+      """,
+
+      "includes/exceptions.thrift": """
+      """,
+
+      "includes/structs.thrift": """
+      struct User {
+        1: i64 id,
+        2: string username,
+        3: string first_name,
+        4: string last_name;
+      }
+
+      struct System {
+        1: string name,
+        2: string hostname
+      }
+      """,
+
+      "job_service.thrift": """
+      include "includes/unions.thrift"
+      include "includes/enums.thrift"
+      include "includes/structs.thrift"
+
+      struct Job {
+        1: i64 job_id,
+        2: unions.JobSubject subject,
+        3: structs.User requester;
+      }
+
+      service JobService {
+        i64 submit(1: Job job),
+        enums.JobStatus get_status(1: i64 job_id),
+        boolean cancel(1: i64 job_id);
+      }
+
+      """, parse: "job_service.thrift") do
+
+      job = FileGroup.resolve(file_group, :"job_service.Job")
+
+      assert %Struct{name: :"job_service.Job"} = job
+      assert %Struct{name: :"structs.User"} = FileGroup.resolve(file_group, :"structs.User")
+      assert %Union{} = FileGroup.resolve(file_group, :"unions.JobSubject")
+      assert %TEnum{} = FileGroup.resolve(file_group, :"enums.JobStatus")
+    end
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -410,9 +410,7 @@ defmodule ParserTest do
 
     assert service == %Service{
       name: :MyService,
-      functions: [
-        %Function{name: :hi, return_type: :void, params: []}
-      ]
+      functions: %{hi: %Function{name: :hi, return_type: :void, params: []}}
     }
   end
 
@@ -429,11 +427,11 @@ defmodule ParserTest do
 
     assert service == %Service{
       name: :MyService,
-      functions: [
+      functions: %{usernames_to_ids:
         %Function{name: :usernames_to_ids, oneway: false, return_type: {:map, {:string, :i64}},
                   params: [%Field{id: 1, name: :user, type: %StructRef{referenced_type: :User}}]
                  }
-      ]
+      }
     }
   end
 
@@ -447,14 +445,14 @@ defmodule ParserTest do
 
     assert service == %Service{
       name: :OneWay,
-      functions: [
-        %Function{
+      functions: %{
+        fireAndForget: %Function{
           name: :fireAndForget, oneway: true, return_type: :void,
           params: [
             %Field{id: 1, name: :value, type: :i64}
           ]
         }
-      ]
+      }
     }
   end
 
@@ -471,7 +469,7 @@ defmodule ParserTest do
     """
     |> parse([:services, :Thrower])
 
-    [function] = service.functions
+    %{blowup: function} = service.functions
     assert function.exceptions == [
       %Field{id: 1, name: :svc, type: %StructRef{referenced_type: :ServiceException}}
     ]
@@ -498,7 +496,7 @@ defmodule ParserTest do
     capture_io fn ->
       service = parse(code, [:services, :MultipleFns])
 
-      [ping, update, get_users] = service.functions
+      %{ping: ping, update: update, get_users: get_users} = service.functions
 
       assert ping == %Function{name: :ping}
       assert update == %Function{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,70 @@
 ExUnit.start()
+
+
+defmodule ThriftTestHelpers do
+  @root_dir "test/fixtures/thrift/"
+
+  defmacro __using__(_) do
+    quote do
+      require ThriftTestHelpers
+      import ThriftTestHelpers
+    end
+  end
+
+  def build_thrift_file(base_dir, {file_name, contents}) do
+    file_relative_path = file_name
+    |> Atom.to_string
+
+
+    file_path = Path.join(base_dir, file_relative_path)
+
+    file_path
+    |> Path.dirname
+    |> File.mkdir_p!
+
+    File.write!(file_path, contents)
+    file_relative_path
+  end
+
+  def tmp_dir do
+    'mktemp -d'
+    |> :os.cmd
+    |> List.to_string
+    |> String.strip
+  end
+
+  def parse(_root_dir, nil) do
+    nil
+  end
+
+  def parse(file_path) do
+    alias Thrift.Parser
+    Parser.parse_file(file_path)
+  end
+
+  @spec with_thrift_files(keyword, String.t) :: nil
+  defmacro with_thrift_files(opts, do: block) do
+    {var_name, opts_1} = Keyword.pop(opts, :as, :file_group)
+    {parsed_file, specs} = Keyword.pop(opts_1, :parse, nil)
+
+    thrift_var = Macro.var(var_name, nil)
+
+    quote location: :keep do
+      root_dir = ThriftTestHelpers.tmp_dir
+      full_path = root_dir
+      |> Path.join(unquote(parsed_file))
+
+      files = unquote(specs)
+      |> Enum.map(&ThriftTestHelpers.build_thrift_file(root_dir, &1))
+      unquote(thrift_var) = ThriftTestHelpers.parse(full_path)
+      try do
+        unquote(block)
+        File.rm_rf!(root_dir)
+      rescue e ->
+        File.rm_rf!(root_dir)
+        raise e
+      end
+    end
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -27,10 +27,11 @@ defmodule ThriftTestHelpers do
   end
 
   def tmp_dir do
-    'mktemp -d'
-    |> :os.cmd
-    |> List.to_string
-    |> String.strip
+    tmp_path = System.tmp_dir!
+    |> Path.join(Integer.to_string(System.unique_integer))
+
+    File.mkdir(tmp_path)
+    tmp_path
   end
 
   def parse(_root_dir, nil) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -42,7 +42,7 @@ defmodule ThriftTestHelpers do
     Parser.parse_file(file_path)
   end
 
-  @spec with_thrift_files(keyword, String.t) :: nil
+  @spec with_thrift_files(Keyword.t, String.t) :: nil
   defmacro with_thrift_files(opts, do: block) do
     {var_name, opts_1} = Keyword.pop(opts, :as, :file_group)
     {parsed_file, specs} = Keyword.pop(opts_1, :parse, nil)


### PR DESCRIPTION
The parser can now take a single thrift file and follow all its
includes and parse them as well. The output is stored in a FileGroup,
which is returned.

Added a resolver to handle resolution of struct references. As
references are added to the FileGroup, they are placed in the resolver
and after parsing is complete, added to the resolutions field in the
FileGroup.

@pguillory @jparise 