### PR TITLE
Fix broken --gen compiler option merging

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -80,11 +80,12 @@ defmodule Mix.Tasks.Compile.Thrift do
   end
 
   defp build_options(output_dir, user_options) do
-    opts = ~w[--out] ++ [output_dir]
-    opts = unless Enum.member?(user_options, "--gen") do
-      opts ++ ~w[--gen erl]
+    opts = if Enum.member?(user_options, "--gen") do
+      user_options
+    else
+      ~w[--gen erl] ++ user_options
     end
-    opts ++ user_options
+    opts ++ ~w[--out] ++ [output_dir]
   end
 
   defp generate(exec, options, thrift_file) do

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -52,6 +52,14 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
+  test "specifying a custom --gen compiler option" do
+    in_fixture fn ->
+      with_project_config [thrift_options: ~w[--gen erl:maps]], fn ->
+        assert capture_io(fn -> run([]) end) =~ "Compiled thrift/tutorial.thrift"
+      end
+    end
+  end
+
   test "specifying an empty :thrift_files list" do
     in_fixture fn ->
       with_project_config [thrift_files: []], fn ->


### PR DESCRIPTION
The previous code attempted to append `nil` to the `opts` list when a
user-provided `--gen` option was given.