### PR TITLE
Sort defs to prevent compile warning

### DIFF
--- a/lib/generator/utils.ex
+++ b/lib/generator/utils.ex
@@ -1,0 +1,28 @@
+defmodule Thrift.Generator.Utils do
+  def merge_blocks([{:__block__, _, contents} | rest]) do
+    merge_blocks(contents) ++ merge_blocks(rest)
+  end
+
+  def merge_blocks([statement | rest]) do
+    [statement | merge_blocks(rest)]
+  end
+
+  def merge_blocks([]) do
+    []
+  end
+
+  def sort_defs(statements) do
+    Enum.sort_by(statements, fn
+      {:def, _, [{:when, _, [{name, _, args} | _]} | _]} ->
+        {name, length(args)}
+      {:defp, _, [{:when, _, [{name, _, args} | _]} | _]} ->
+        {name, length(args)}
+      {:def, _, [{name, _, args} | _]} ->
+        {name, length(args)}
+      {:defp, _, [{name, _, args} | _]} ->
+        {name, length(args)}
+      {:=, _, [{:_, _, _} | _]} ->
+        nil
+    end)
+  end
+end

--- a/lib/protocols/binary.ex
+++ b/lib/protocols/binary.ex
@@ -1,5 +1,6 @@
 defmodule Thrift.Protocols.Binary do
   alias Thrift.Parser.FileGroup
+  alias Thrift.Generator.Utils
 
   # field types, which are the type ids from the thrift spec.
   @bool 2
@@ -40,12 +41,18 @@ defmodule Thrift.Protocols.Binary do
     alias Thrift.Generator.Models.BinaryProtocol, as: Deserializer
     name = FileGroup.dest_module(file_group, struct.name)
 
+    defs = [
+      primitive_serializers,
+      generate_serializer(file_group, struct),
+      # Commented out due to compilation failures
+      # Deserializer.struct_deserializer(struct, name, file_group),
+    ]
+    |> Utils.merge_blocks
+    |> Utils.sort_defs
+
     quote do
       defmodule BinaryProtocol do
-        unquote(primitive_serializers)
-        unquote(generate_serializer(file_group, struct))
-        # Commented out due to compilation failures
-        #unquote(Deserializer.struct_deserializer(struct, name, file_group))
+        unquote_splicing(defs)
       end
     end
   end


### PR DESCRIPTION
Sometimes deserialize* methods are generated out of the order expected by Elixir. This change flattens nested blocks and then sorts them to eliminate the error.