### PR TITLE
Make Protocols.Binary statically available

### DIFF
--- a/lib/generator/binary_protocol.ex
+++ b/lib/generator/binary_protocol.ex
@@ -80,9 +80,12 @@ defmodule Thrift.Generator.Models.BinaryProtocol do
     |> Utils.merge_blocks
 
     quote do
-      def serialize2(unquote(struct_matcher)) do
+      def serialize(unquote(struct_matcher)) do
         unquote([field_serializers, <<0>>] |> Utils.merge_binaries)
       end
+      def bool_to_int(false), do: 0
+      def bool_to_int(nil), do: 0
+      def bool_to_int(_), do: 1
 
       def deserialize(binary) do
         deserialize(binary, %unquote(name){})

--- a/lib/generator/models.ex
+++ b/lib/generator/models.ex
@@ -129,13 +129,10 @@ defmodule Thrift.Generator.Models do
         def new, do: %__MODULE__{}
         unquote(binary_protocol)
         def serialize(struct) do
-          BinaryProtocol.serialize(:struct, struct)
+          BinaryProtocol.serialize(struct)
         end
         def serialize(struct, :binary) do
-          BinaryProtocol.serialize(:struct, struct)
-        end
-        def serialize(struct, :binary2) do
-          BinaryProtocol.serialize2(struct)
+          BinaryProtocol.serialize(struct)
         end
         def serialize(struct, :compact) do
           CompactProtocol.serialize(:struct, struct)

--- a/lib/protocols/binary.ex
+++ b/lib/protocols/binary.ex
@@ -42,8 +42,6 @@ defmodule Thrift.Protocols.Binary do
     name = FileGroup.dest_module(file_group, struct.name)
 
     defs = [
-      primitive_serializers,
-      generate_serializer(file_group, struct),
       Deserializer.struct_deserializer(struct, name, file_group),
     ]
     |> Utils.merge_blocks
@@ -56,209 +54,78 @@ defmodule Thrift.Protocols.Binary do
     end
   end
 
-  def primitive_serializers do
-    type_converters = for {atom_type, int_type} <- @types do
-      quote do
-        def int_type(unquote(atom_type)) do
-          unquote(int_type)
-        end
-      end
-    end
-
-    quote location: :keep do
-      unquote_splicing(type_converters)
-      def int_type({:map, _}), do: 13
-      def int_type({:set, _}), do: 14
-      def int_type({:list, _}), do: 15
-
-      defp bool_to_int(false), do: 0
-      defp bool_to_int(nil), do: 0
-      defp bool_to_int(_), do: 1
-
-      defp to_message_type(:call), do: 1
-      defp to_message_type(:reply), do: 2
-      defp to_message_type(:exception), do: 3
-      defp to_message_type(:oneway), do: 4
-
-      def serialize(_, nil) do
-        []
-      end
-      def serialize(:bool, value) do
-        value = bool_to_int(value)
-        unquote(integer_serializer(8))
-      end
-      def serialize(:i8, value) do
-        unquote(integer_serializer(8))
-      end
-      def serialize(:i16, value) do
-        unquote(integer_serializer(16))
-      end
-      def serialize(:i32, value) do
-        unquote(integer_serializer(32))
-      end
-      def serialize(:i64, value) do
-        unquote(integer_serializer(64))
-      end
-      def serialize(:double, value) do
-        <<value::signed-float>>
-      end
-      def serialize(:string, value) do
-        [<<byte_size(value)::size(32)>>, value]
-      end
-      def serialize(:binary, value) do
-        [<<byte_size(value)::size(32)>>, value]
-      end
-      def serialize({:list, elem_type}, elems) when is_list(elems) do
-        rest = Enum.map(elems, &serialize(elem_type, &1))
-
-        [<<int_type(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
-      end
-      def serialize({:set, elem_type}, %MapSet{}=elems) do
-        rest = Enum.map(elems, &serialize(elem_type, &1))
-
-        [<<int_type(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
-      end
-      def serialize({:map, {key_type, val_type}}, map) when is_map(map) do
-        elem_count = map_size(map)
-        rest = Enum.map(map, fn {key, value} ->
-          [serialize(key_type, key), serialize(val_type, value)]
-        end)
-        [<<int_type(key_type)::size(8), int_type(val_type)::size(8), elem_count::32-signed>>, rest]
-      end
-
-      def serialize(:message_begin, {sequence_id, message_type, name}) do
-        # Taken from https://erikvanoosten.github.io/thrift-missing-specification/#_message_encoding
-
-        <<1::size(1), 1::size(15), 0::size(8),
-        # ^^ Strange, I know. We could integrate the 8-bit zero here with the 5 bit zero below.
-        0::size(5), to_message_type(message_type)::size(3),
-        byte_size(name)::32-signed, sequence_id::32-signed>>
-      end
+  for {atom_type, int_type} <- @types do
+    def int_type(unquote(atom_type)) do
+      unquote(int_type)
     end
   end
+  def int_type({:map, _}), do: 13
+  def int_type({:set, _}), do: 14
+  def int_type({:list, _}), do: 15
 
-  defp generate_serializer(file_group, %Struct{}=struct) do
-    generate_generic_serializer(file_group, struct, :struct)
+  defp bool_to_int(false), do: 0
+  defp bool_to_int(nil), do: 0
+  defp bool_to_int(_), do: 1
+
+  defp to_message_type(:call), do: 1
+  defp to_message_type(:reply), do: 2
+  defp to_message_type(:exception), do: 3
+  defp to_message_type(:oneway), do: 4
+
+  def serialize(_, nil) do
+    []
   end
-
-  defp generate_serializer(file_group, %Exception{}=ex) do
-    generate_generic_serializer(file_group, ex, :exception)
+  def serialize(:bool, value) do
+    value = bool_to_int(value)
+    <<value::8-signed>>
   end
-
-  defp generate_generic_serializer(file_group, %{fields: fields, name: name}, match_type) do
-    serializers = fields
-    |> Enum.sort_by(&(&1.id))
-    |> Enum.map(&FileGroup.resolve(file_group, &1))
-    |> Enum.map(&generate_field_call(file_group, &1))
-    |> append_struct_stop
-
-    dest_module = FileGroup.dest_module(file_group, name)
-    field_match = generate_field_match(dest_module, fields)
-
-    quote do
-      def serialize(unquote(match_type), unquote(field_match)) do
-        unquote(serializers)
-      end
-    end
+  def serialize(:i8, value) do
+    <<value::8-signed>>
   end
-
-  defp to_generic_type(type) do
-    case type do
-      {:map, {key_type, val_type}} ->
-        {:map, {to_generic_type(key_type), to_generic_type(val_type)}}
-
-      {:list, elem_type} ->
-        {:list, to_generic_type(elem_type)}
-
-      {:set, elem_type} ->
-        {:set, to_generic_type(elem_type)}
-
-      %TEnum{} ->
-        :i32
-
-      val when is_map(val) ->
-        :struct
-
-      val ->
-        val
-    end
+  def serialize(:i16, value) do
+    <<value::16-signed>>
   end
-
-  defp generate_field_call(file_group, %Field{type: %Struct{}}=field) do
-    dest_module = file_group
-    |> FileGroup.dest_module(field.type)
-    |> Module.concat(BinaryProtocol)
-    |> field_serializer_stanza(field)
+  def serialize(:i32, value) do
+    <<value::32-signed>>
   end
-
-  defp generate_field_call(file_group, %Field{}=field) do
-    field = FileGroup.resolve(file_group, field)
-    generic_type = to_generic_type(field.type)
-
-    self = quote do: __MODULE__
-    field_serializer_stanza(self, field)
+  def serialize(:i64, value) do
+    <<value::64-signed>>
   end
-
-  def header_for(%Field{type: type}=field) do
-    type_name = case type do
-                  primitive when is_atom(primitive) ->
-                    primitive
-
-                  {composite, _} ->
-                    composite
-
-                  %TEnum{} ->
-                    :i32
-
-                  %Struct{} ->
-                    :struct
-                end
-    @types
-    |> Map.get(type_name)
-    |> build_struct_field_header(field)
+  def serialize(:double, value) do
+    <<value::signed-float>>
   end
-
-  defp build_struct_field_header(type, field) do
-    quote do
-      <<unquote(type)::size(8), unquote(field.id)::size(16)>>
-    end
+  def serialize(:string, value) do
+    [<<byte_size(value)::size(32)>>, value]
   end
-
-  defp integer_serializer(bit_size) do
-    quote do
-      <<value::unquote(bit_size)-signed>>
-    end
+  def serialize(:binary, value) do
+    [<<byte_size(value)::size(32)>>, value]
   end
+  def serialize({:list, elem_type}, elems) when is_list(elems) do
+    rest = Enum.map(elems, &serialize(elem_type, &1))
 
-  defp append_struct_stop(serializers) do
-    quoted_stop = quote do
-      <<0::size(8)>>
-    end
-
-    serializers ++ [quoted_stop]
+    [<<int_type(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
   end
+  def serialize({:set, elem_type}, %MapSet{}=elems) do
+    rest = Enum.map(elems, &serialize(elem_type, &1))
 
-  defp generate_field_match(dest_module, field_list) do
-    match_kw = field_list
-    |> Enum.map(fn(field) ->
-      {field.name, Macro.var(field.name, Elixir)}
+    [<<int_type(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
+  end
+  def serialize({:map, {key_type, val_type}}, map) when is_map(map) do
+    elem_count = map_size(map)
+    rest = Enum.map(map, fn {key, value} ->
+      [serialize(key_type, key), serialize(val_type, value)]
     end)
-
-    {:%, [],
-     [{:__aliases__, [alias: false], [dest_module]},
-      {:%{}, [], match_kw}]}
+    [<<int_type(key_type)::size(8), int_type(val_type)::size(8), elem_count::32-signed>>, rest]
   end
+  def serialize(:struct, %{__struct__: mod}=struct) do
+    mod.serialize(struct, :binary)
+  end
+  def serialize(:message_begin, {sequence_id, message_type, name}) do
+    # Taken from https://erikvanoosten.github.io/thrift-missing-specification/#_message_encoding
 
-  defp field_serializer_stanza(serializer_module, %Field{}=field) do
-    field_var = Macro.var(field.name, Elixir)
-    field_type = to_generic_type(field.type)
-    quote do
-      case unquote(field_var) do
-        nil ->
-          []
-        field_value ->
-          [unquote(header_for(field)), unquote(serializer_module).serialize(unquote(field_type), field_value)]
-      end
-    end
+    <<1::size(1), 1::size(15), 0::size(8),
+    # ^^ Strange, I know. We could integrate the 8-bit zero here with the 5 bit zero below.
+    0::size(5), to_message_type(message_type)::size(3),
+    byte_size(name)::32-signed, sequence_id::32-signed>>
   end
 end

--- a/test/generator/binary_protocol_test.exs
+++ b/test/generator/binary_protocol_test.exs
@@ -1,15 +1,15 @@
 defmodule Thrift.Generator.BinaryProtocolTest do
   use ThriftTestCase
 
+  alias Thrift.Protocols.Binary
+
   def assert_serializes(struct=%{__struct__: mod}, binary) do
-    # assert ^binary = mod.serialize(struct) |> IO.iodata_to_binary
-    assert binary == mod.serialize(struct, :binary2) |> IO.iodata_to_binary
+    assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
     assert {^struct, ""} = mod.deserialize(binary)
   end
 
   def assert_serializes(struct=%{__struct__: mod}, binary, deserialized_struct=%{__struct__: mod}) do
-    # assert ^binary = mod.serialize(struct) |> IO.iodata_to_binary
-    assert binary == mod.serialize(struct, :binary2) |> IO.iodata_to_binary
+    assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
     assert {^deserialized_struct, ""} = mod.deserialize(binary)
   end
 

--- a/test/protocols/binary_test.exs
+++ b/test/protocols/binary_test.exs
@@ -8,7 +8,7 @@ defmodule BinaryProtocolTest do
     {serializer_mod, serializer_fn} = serializer_mf
     {deserializer_mod, deserializer_fn} = deserializer_mf
 
-    serialized = :erlang.apply(serializer_mod, serializer_fn, [:struct, data])
+    serialized = :erlang.apply(serializer_mod, serializer_fn, [data, :binary])
     |> IO.iodata_to_binary
 
     :erlang.apply(deserializer_mod, deserializer_fn, [serialized])
@@ -27,7 +27,7 @@ defmodule BinaryProtocolTest do
   }
   """
   thrift_test "encoding enums" do
-    encoder = {StructWithEnum.BinaryProtocol, :serialize}
+    encoder = {StructWithEnum, :serialize}
     decoder = {Erlang.Enums, :deserialize_struct_with_enum}
 
     assert {:StructWithEnum, 1} == round_trip_struct(StructWithEnum.new, encoder, decoder)
@@ -56,7 +56,7 @@ defmodule BinaryProtocolTest do
   """
 
   thrift_test "it should be able to encode scalar values" do
-    encoder = {Scalars.BinaryProtocol, :serialize}
+    encoder = {Scalars, :serialize}
     decoder = {Erlang.Scalars, :deserialize_scalars}
 
     assert Erlang.Scalars.new_scalars(is_true: true) == round_trip_struct(%Scalars{is_true: true}, encoder, decoder)
@@ -77,7 +77,7 @@ defmodule BinaryProtocolTest do
   end
 
   thrift_test "it should not encode unset fields" do
-    encoded =  Scalars.BinaryProtocol.serialize(:struct, %Scalars{})
+    encoded =  Scalars.serialize(%Scalars{})
     |> IO.iodata_to_binary
 
     assert <<0>> == encoded
@@ -109,7 +109,7 @@ defmodule BinaryProtocolTest do
   """
 
   thrift_test "containers serialize properly" do
-    encoder = {Containers.BinaryProtocol, :serialize}
+    encoder = {Containers, :serialize}
     decoder = {Erlang.Containers, :deserialize_containers}
 
     # unset containers become undefined
@@ -155,7 +155,7 @@ defmodule BinaryProtocolTest do
   """
 
   thrift_test "serializing structs across modules" do
-    encoder = {User.BinaryProtocol, :serialize}
+    encoder = {User, :serialize}
     decoder = {Erlang.Across, :deserialize_user}
 
     erl_user = Erlang.Across.new_user(

--- a/test/support/lib/parser_utils.ex
+++ b/test/support/lib/parser_utils.ex
@@ -92,7 +92,7 @@ defmodule ParserUtils do
 
   def serialize_user2(user, opts) when is_map(user) do
     alias User.BinaryProtocol
-    serialized = BinaryProtocol.serialize2(user)
+    serialized = BinaryProtocol.serialize(user)
 
     if Keyword.get(opts, :convert_to_binary, true) do
       IO.iodata_to_binary(serialized)


### PR DESCRIPTION
This makes the generic serialization functionality in Protocols.Binary statically available, rather than putting it into generated models, so you can serialize arbitrary values at runtime. For example you could serialize a list of i32s with:
```
Thrift.Protocols.Binary.serialize({:list, :i32}, [5, 6, 7, 8])
```
Struct serialization is passed through to models based on the __struct__ field.