### PR TITLE
Support file argument to thrift.generate

### DIFF
--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -4,22 +4,39 @@ defmodule Mix.Tasks.Thrift.Generate do
   @moduledoc """
   Generate Elixir modules from Thrift schema definitions.
 
-  ## Command line options
+  Syntax:
+    mix thrift.generate [options] myfile.thrift
+    mix thrift.generate [options] dir_with_thrift_files
 
-    * `--thrift-dir` - Directory to scan for .thrift files. (Default: ./thrift)
+  ## Command line options
     * `--output-dir` - Directory under which to place generated .ex files. (Default: ./lib)
   """
 
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args)
-
-    thrift_dir = Keyword.get(opts, :thrift_dir, "thrift")
+    {opts, args, _} = OptionParser.parse(args)
+    if args == [] do
+      print_help
+      exit :normal
+    end
+    [input | _] = args
     output_dir = Keyword.get(opts, :output_dir, "lib")
 
-    for thrift_file <- Mix.Utils.extract_files([thrift_dir], "*.thrift") do
+    thrift_files = cond do
+      File.dir?(input) ->
+        Mix.Utils.extract_files([input], "*.thrift")
+      File.regular?(input) ->
+        [input]
+    end
+
+    for thrift_file <- thrift_files do
       for output_file <- Thrift.Generator.generate!(thrift_file, output_dir) do
         Mix.shell.info "Generated #{output_file}"
       end
     end
+  end
+
+  defp print_help do
+    Mix.Task.moduledoc(__MODULE__)
+    |> Mix.shell.info
   end
 end

--- a/test/mix/tasks/thrift.generate_test.exs
+++ b/test/mix/tasks/thrift.generate_test.exs
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Thrift.GenerateTest do
       }
       """
 
-    output = capture_io(fn -> run(["--thrift-dir", dir, "--output-dir", dir]) end)
+    output = capture_io(fn -> run([dir, "--output-dir", dir]) end)
 
     assert String.contains? output, "Generated shared/shared_struct.ex"
     assert String.contains? output, "Generated shared/shared_exception.ex"


### PR DESCRIPTION
This gives the user more fine grained control over which .thrift files are
processed. For instance, a directory might contain many files but you only want
one or a few.