### PR TITLE
Fix CompactProtocol warning

### DIFF
--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -36,9 +36,6 @@ defmodule Thrift.Generator.StructGenerator do
         def serialize(struct, :binary) do
           BinaryProtocol.serialize(struct)
         end
-        def serialize(struct, :compact) do
-          CompactProtocol.serialize(:struct, struct)
-        end
         def deserialize(binary) do
           BinaryProtocol.deserialize(binary)
         end


### PR DESCRIPTION
A reference was left in the code to this module, but it doesn't exist (yet).

Fixes #55.