### PR TITLE
Added generation for service structs

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -1,6 +1,7 @@
 defmodule Thrift.Generator do
   alias Thrift.Parser.FileGroup
   alias Thrift.Generator.EnumGenerator
+  alias Thrift.Generator.Service, as: ServiceGenerator
   alias Thrift.Generator.StructGenerator
 
   def generate!(thrift_filename, output_dir) when is_bitstring(thrift_filename) do
@@ -36,6 +37,7 @@ defmodule Thrift.Generator do
       generate_enum_modules(schema),
       generate_struct_modules(schema),
       generate_exception_modules(schema),
+      generate_services(schema),
     ])
   end
 
@@ -76,6 +78,12 @@ defmodule Thrift.Generator do
     for {_, exception} <- schema.exceptions do
       full_name = FileGroup.dest_module(schema.file_group, exception)
       {full_name, StructGenerator.generate("exception", schema, full_name, exception)}
+    end
+  end
+
+  defp generate_services(schema) do
+    for {_, service} <- schema.services do
+      ServiceGenerator.generate(schema, service)
     end
   end
 end

--- a/lib/thrift/generator/service_generator.ex
+++ b/lib/thrift/generator/service_generator.ex
@@ -1,0 +1,61 @@
+defmodule Thrift.Generator.Service do
+  alias Thrift.Parser.FileGroup
+  alias Thrift.Generator.StructGenerator
+  alias Thrift.Parser.Models.{
+    Field,
+    Function,
+    Struct
+  }
+
+  def generate(schema, service) do
+    file_group = schema.file_group
+    dest_module = FileGroup.dest_module(file_group, service)
+
+    functions = service.functions |> Map.values
+    arg_structs = Enum.map(functions, &generate_args_struct(schema, &1))
+    response_structs = Enum.map(functions, &generate_response_struct(schema, &1))
+
+    service_module = quote do
+      defmodule unquote(dest_module) do
+        unquote_splicing(arg_structs)
+        unquote_splicing(response_structs)
+      end
+    end
+
+    {dest_module, service_module}
+  end
+
+  def generate_args_struct(schema, function) do
+    arg_module_name = service_module_name(function, :args)
+
+    struct = Struct.new(Atom.to_charlist(arg_module_name), function.params)
+
+    StructGenerator.generate(:struct, schema, struct.name, struct)
+  end
+
+  def generate_response_struct(schema, function) do
+    success = %Field{id: 0,
+                     name: :success,
+                     required: true,
+
+                     type: function.return_type}
+
+    exceptions = function.exceptions
+    |> Enum.map(&Map.put(&1, :required, false))
+
+    fields = [success | exceptions]
+
+    response_module_name = service_module_name(function, :response)
+    response_struct = Struct.new(Atom.to_charlist(response_module_name), fields)
+
+    StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
+  end
+
+  defp service_module_name(%Function{}=function, suffix) do
+    struct_name = "#{function.name}_#{suffix}"
+    |> Macro.camelize
+    |> String.to_atom
+
+    Module.concat(Elixir, struct_name)
+  end
+end

--- a/lib/thrift/generator/service_generator.ex
+++ b/lib/thrift/generator/service_generator.ex
@@ -45,7 +45,7 @@ defmodule Thrift.Generator.Service do
     fields = [success | exceptions]
 
     response_module_name = service_module_name(function, :response)
-    response_struct = Struct.new(Atom.to_charlist(response_module_name), fields)
+    response_struct = Struct.new(Atom.to_char_list(response_module_name), fields)
 
     StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
   end

--- a/lib/thrift/generator/service_generator.ex
+++ b/lib/thrift/generator/service_generator.ex
@@ -28,7 +28,7 @@ defmodule Thrift.Generator.Service do
   def generate_args_struct(schema, function) do
     arg_module_name = service_module_name(function, :args)
 
-    struct = Struct.new(Atom.to_charlist(arg_module_name), function.params)
+    struct = Struct.new(Atom.to_char_list(arg_module_name), function.params)
 
     StructGenerator.generate(:struct, schema, struct.name, struct)
   end
@@ -37,7 +37,6 @@ defmodule Thrift.Generator.Service do
     success = %Field{id: 0,
                      name: :success,
                      required: true,
-
                      type: function.return_type}
 
     exceptions = function.exceptions

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -19,6 +19,7 @@ defmodule Thrift.Parser.FileGroup do
     Namespace,
     StructRef,
     Schema,
+    Service,
     Struct,
   }
 
@@ -121,6 +122,10 @@ defmodule Thrift.Parser.FileGroup do
   end
 
   def dest_module(file_group, %TEnum{name: name}) do
+    dest_module(file_group, name)
+  end
+
+  def dest_module(file_group, %Service{name: name}) do
     dest_module(file_group, name)
   end
 

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -1,0 +1,69 @@
+defmodule ServiceTest do
+  use ThriftTestCase
+
+  @thrift_file name: "simple_service.thrift", contents: """
+  namespace elixir Services.Simple
+  struct User {
+    1: i64 id,
+    2: string username
+  }
+
+  exception UsernameTakenException {
+    1: string message
+  }
+
+  service SimpleService {
+    bool update_username(1: i64 id, 2: string new_username)
+      throws(1: UsernameTakenException taken),
+  }
+  """
+
+  thrift_test "it should generate arg structs" do
+    find_by_id_args = %SimpleService.UpdateUsernameArgs{id: 1234, new_username: "foobar"}
+    assert find_by_id_args.id == 1234
+    assert find_by_id_args.new_username == "foobar"
+
+  end
+
+  thrift_test "it should generate response structs" do
+    response = %SimpleService.UpdateUsernameResponse{success: true}
+    assert :success in Map.keys(response)
+  end
+
+  thrift_test "it should generate exceptions in response structs" do
+    assert :taken in Map.keys(%SimpleService.UpdateUsernameResponse{})
+  end
+
+  thrift_test "it should be able to serialize the request struct" do
+    alias SimpleService.UpdateUsernameArgs
+
+    serialized = %UpdateUsernameArgs{id: 1234, new_username: "stinkypants"}
+    |> UpdateUsernameArgs.BinaryProtocol.serialize
+    |> IO.iodata_to_binary
+
+    assert <<10, 0, 1, 0, 0, 0, 0, 0, 0, 4, 210, 11, 0, 2, 0, 0, 0, 11, "stinkypants", 0>> == serialized
+  end
+
+  thrift_test "it should be able to serialize the response struct" do
+    alias SimpleService.UpdateUsernameResponse
+    serialized = %UpdateUsernameResponse{success: true}
+    |> UpdateUsernameResponse.BinaryProtocol.serialize
+    |> IO.iodata_to_binary
+
+    assert <<2, 0, 0, 1, 0>> == serialized
+  end
+
+  thrift_test "it serializes the exceptions" do
+    # this is because the python client always expects the success struct.
+    # silly python client.
+
+    alias SimpleService.UpdateUsernameResponse
+
+    serialized = %UpdateUsernameResponse{taken: %UsernameTakenException{message: "That username is taken"}}
+    |> UpdateUsernameResponse.BinaryProtocol.serialize
+    |> IO.iodata_to_binary
+
+    assert <<12, 0, 1, 11, 0, 1, 0, 0, 0, 22, rest::binary>> = serialized
+    assert <<"That username is taken", 0, 0>> = rest
+  end
+end

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -1,4 +1,4 @@
-defmodule ServiceTest do
+defmodule Thrift.Generator.ServiceTest do
   use ThriftTestCase
 
   @thrift_file name: "simple_service.thrift", contents: """
@@ -22,7 +22,6 @@ defmodule ServiceTest do
     find_by_id_args = %SimpleService.UpdateUsernameArgs{id: 1234, new_username: "foobar"}
     assert find_by_id_args.id == 1234
     assert find_by_id_args.new_username == "foobar"
-
   end
 
   thrift_test "it should generate response structs" do


### PR DESCRIPTION
Thrift models RPC function arguments and responses as structs. This adds
generation for struct args and responses

@pguillory 