### PR TITLE
Add a custom Credo configuration file

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,64 @@
+%{configs: [
+  %{name: "default",
+    files: %{
+      included: ["lib/", "test/"],
+      excluded: ["_build/", "deps/", "ext/"]
+    },
+    requires: [],
+    check_for_updates: false,
+
+    # You can customize the parameters of any check by adding a second element
+    # to the tuple.
+    #
+    # To disable a check put `false` as second element:
+    #
+    #     {Credo.Check.Design.DuplicatedCode, false}
+    #
+    checks: [
+      {Credo.Check.Consistency.ExceptionNames},
+      {Credo.Check.Consistency.LineEndings},
+      {Credo.Check.Consistency.SpaceAroundOperators},
+      {Credo.Check.Consistency.SpaceInParentheses},
+      {Credo.Check.Consistency.TabsOrSpaces},
+
+      {Credo.Check.Design.AliasUsage, false},
+      {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+
+      {Credo.Check.Readability.FunctionNames},
+      {Credo.Check.Readability.LargeNumbers, false},
+      {Credo.Check.Readability.MaxLineLength, false},
+      {Credo.Check.Readability.ModuleAttributeNames},
+      {Credo.Check.Readability.ModuleNames},
+      {Credo.Check.Readability.ParenthesesInCondition},
+      {Credo.Check.Readability.PredicateFunctionNames},
+      {Credo.Check.Readability.TrailingBlankLine},
+      {Credo.Check.Readability.TrailingWhiteSpace},
+      {Credo.Check.Readability.VariableNames},
+      {Credo.Check.Readability.RedundantBlankLines},
+
+      {Credo.Check.Refactor.ABCSize, false},
+      {Credo.Check.Refactor.CondStatements},
+      {Credo.Check.Refactor.MatchInCondition},
+      {Credo.Check.Refactor.PipeChainStart, false},
+      {Credo.Check.Refactor.CyclomaticComplexity},
+      {Credo.Check.Refactor.NegatedConditionsInUnless},
+      {Credo.Check.Refactor.NegatedConditionsWithElse},
+      {Credo.Check.Refactor.Nesting},
+      {Credo.Check.Refactor.UnlessWithElse},
+
+      {Credo.Check.Warning.IExPry},
+      {Credo.Check.Warning.IoInspect, false},
+      {Credo.Check.Warning.NameRedeclarationByAssignment, false},
+      {Credo.Check.Warning.NameRedeclarationByCase, false},
+      {Credo.Check.Warning.NameRedeclarationByDef, false},
+      {Credo.Check.Warning.NameRedeclarationByFn, false},
+      {Credo.Check.Warning.BoolOperationOnSameValues},
+      {Credo.Check.Warning.UnusedEnumOperation},
+      {Credo.Check.Warning.UnusedKeywordOperation},
+      {Credo.Check.Warning.UnusedListOperation},
+      {Credo.Check.Warning.UnusedStringOperation},
+      {Credo.Check.Warning.UnusedTupleOperation},
+      {Credo.Check.Warning.OperationWithConstantResult},
+    ]
+  }
+]}

--- a/.ebert.yml
+++ b/.ebert.yml
@@ -1,10 +1,10 @@
+styleguide: false
 engines:
   credo:
-    enabled: true
-  fixme:
     enabled: true
   remark-lint:
     enabled: true
 exclude_paths:
+- ci
+- doc
 - ext
-- test

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -140,7 +140,6 @@ defmodule ParserTest do
     constant = "const set<string> SET_CONST = {\"hello\", \"bye\"}"
     |> parse([:constants, :SET_CONST])
 
-
     assert constant == %Constant{name: :SET_CONST,
                                  value: MapSet.new(["hello", "bye"]),
                                  type: {:set, :string}}
@@ -158,7 +157,6 @@ defmodule ParserTest do
   test "parsing a map constant" do
     constant = "const map<string, i32> MAP_CONST = {\"hello\": 1, \"world\": 2};"
     |> parse([:constants, :MAP_CONST])
-
 
     assert constant == %Constant{name: :MAP_CONST,
                                  value: %{"world" => 2, "hello" => 1},
@@ -406,7 +404,6 @@ defmodule ParserTest do
     }
     """
     |> parse([:services, :MyService])
-
 
     assert service == %Service{
       name: :MyService,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,5 @@
 ExUnit.start()
 
-
 defmodule ThriftTestHelpers do
   @root_dir "test/fixtures/thrift/"
 
@@ -14,7 +13,6 @@ defmodule ThriftTestHelpers do
   def build_thrift_file(base_dir, {file_name, contents}) do
     file_relative_path = file_name
     |> Atom.to_string
-
 
     file_path = Path.join(base_dir, file_relative_path)
 


### PR DESCRIPTION
This is based on Ecto's configuration and tweaks a number of defaults
rules to be more lenient than the stock configuration.