### PR TITLE
Test only the oldest and newest Elixir/OTP pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ elixir:
   - 1.3.4
 otp_release:
   - 18.2
-  - 18.3
-  - 19.0
+  - 19.1
+matrix:
+  # We are only interested on the newest/oldest pair
+  exclude:
+    - elixir: 1.3.4
+      otp_release: 18.2
+    - elixir: 1.2.6
+      otp_release: 19.1
 sudo: required
 group: edge
 services: docker


### PR DESCRIPTION
This speeds up our tests builds a bit by eliminating less useful
combinations.