### PR TITLE
We don't need to set MIX_ENV for `mix coveralls`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services: docker
 env:
   - THRIFT=${TRAVIS_BUILD_DIR}/ci/thrift-docker
 after_script:
-  - MIX_ENV=test mix coveralls.travis
+  - mix coveralls.travis
 cache:
   directories:
   - $HOME/.mix/archives

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,11 @@ defmodule Thrift.Mixfile do
 
      # Testing
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test],
+     preferred_cli_env: [
+       "coveralls": :test,
+       "coveralls.detail": :test,
+       "coveralls.html": :test,
+       "coveralls.post": :test],
 
      # URLs
      source_url: @project_url,
@@ -43,7 +47,7 @@ defmodule Thrift.Mixfile do
 
   defp deps do
      [{:ex_doc, "~> 0.14", only: :dev},
-      {:excoveralls, "~> 0.5.7", only: :test},
+      {:excoveralls, "~> 0.5.7", only: [:dev, :test]},
       {:credo, "~> 0.5", only: [:dev, :test]},
       {:dialyxir, "~> 0.4.0", only: [:dev, :test]}
      ]


### PR DESCRIPTION
This is already handled by our `preferred_cli_env` setup.