### PR TITLE
Move the field serializer into its own function

### DIFF
--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -79,21 +79,8 @@ defmodule Thrift.Generator.StructBinaryProtocol do
                          quote do: %unquote(name){unquote_splicing(field_matchers)}
                      end
 
-    field_serializers = Enum.map(fields,
-      fn %Field{name: name, type: type, id: id} ->
-        var = Macro.var(name, nil)
-        quote do
-          case unquote(var) do
-            nil ->
-              <<>>
-              _ ->
-              unquote([
-                quote do <<unquote(type_id(type, file_group)), unquote(id) :: size(16)>> end,
-                value_serializer(type, var, file_group)
-              ] |> Utils.merge_binaries |> Utils.simplify_iolist)
-          end
-        end
-    end)
+    field_serializers = fields
+    |> Enum.map(&field_serializer(&1, file_group))
 
     field_deserializers = fields
     |> Enum.map(&field_deserializer(&1.type, &1, :deserialize, file_group))
@@ -207,6 +194,21 @@ defmodule Thrift.Generator.StructBinaryProtocol do
       end
       defp skip_struct(_) do
         :error
+      end
+    end
+  end
+
+  defp field_serializer(%Field{name: name, type: type, id: id}, file_group) do
+    var = Macro.var(name, nil)
+    quote do
+      case unquote(var) do
+        nil ->
+          <<>>
+        _ ->
+          unquote([
+            quote do <<unquote(type_id(type, file_group)), unquote(id) :: size(16)>> end,
+            value_serializer(type, var, file_group)
+          ] |> Utils.merge_binaries |> Utils.simplify_iolist)
       end
     end
   end


### PR DESCRIPTION
This helps reduce the complexity of struct_deserializer/2 a bit without
changing the functionality.