### PR TITLE
Match unions with zero or one field set

### DIFF
--- a/bench/union_serialization.exs
+++ b/bench/union_serialization.exs
@@ -1,0 +1,25 @@
+defmodule UnionSerializationBenchmark do
+  use Benchfella
+
+  @thrift_file_path "./test/fixtures/app/thrift/simple.thrift"
+  import ParserUtils
+
+  setup_all do
+    parse_thrift(@thrift_file_path)
+    |> compile_module
+
+    {:ok, :ok}
+  end
+
+  before_each_bench _ do
+    user = %User{u: %TestUnion{s: "foo"}}
+    {:ok, user: user}
+  end
+
+  bench "serialize union" do
+    for _ <- 1..1000 do
+      User.BinaryProtocol.serialize(bench_context[:user])
+    end
+    :ok
+  end
+end

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -12,6 +12,7 @@ defmodule Thrift.Generator.StructGenerator do
     end)
 
     binary_protocol_defs = [
+      StructBinaryProtocol.struct_serializer(struct, name, schema.file_group),
       StructBinaryProtocol.struct_deserializer(struct, name, schema.file_group),
     ]
     |> Utils.merge_blocks

--- a/test/fixtures/app/thrift/simple.thrift
+++ b/test/fixtures/app/thrift/simple.thrift
@@ -1,5 +1,11 @@
 include "shared.thrift"
 
+union TestUnion {
+  1: string s,
+  2: i64 i,
+  3: map<string, string> m
+}
+
 struct User {
   1: bool is_evil,
   2: i64 user_id,
@@ -12,6 +18,7 @@ struct User {
   9: map<byte, string> my_map,
   10: set<i32> blocked_user_ids,
   11: optional list<i32> optional_integers,
+  12: TestUnion u
 }
 
 struct Nesting {

--- a/test/support/lib/parser_utils.ex
+++ b/test/support/lib/parser_utils.ex
@@ -1,20 +1,25 @@
 defmodule User do
+  @moduledoc false
   defstruct is_evil: false, user_id: 0, number_of_hairs_on_head: 0, amount_of_red: 0, nineties_era_color: 0, mint_gum: 0.0, username: "", friends: [], my_map: %{}, blocked_user_ids: MapSet.new(), optional_integers: [], u: nil
 end
 
 defmodule TestUnion do
+  @moduledoc false
   defstruct s: nil, i: nil, m: nil
 end
 
 defmodule Nesting do
+  @moduledoc false
   defstruct user: nil, nested: nil
 end
 
 defmodule Shared.SharedStruct do
+  @moduledoc false
   defstruct key: nil, value: nil
 end
 
 defmodule ParserUtils do
+  @moduledoc false
   alias Thrift.Parser
 
   def parse_thrift(file_path) do

--- a/test/support/lib/parser_utils.ex
+++ b/test/support/lib/parser_utils.ex
@@ -1,5 +1,9 @@
 defmodule User do
-  defstruct is_evil: false, user_id: 0, number_of_hairs_on_head: 0, amount_of_red: 0, nineties_era_color: 0, mint_gum: 0.0, username: "", friends: [], my_map: %{}, blocked_user_ids: MapSet.new(), optional_integers: []
+  defstruct is_evil: false, user_id: 0, number_of_hairs_on_head: 0, amount_of_red: 0, nineties_era_color: 0, mint_gum: 0.0, username: "", friends: [], my_map: %{}, blocked_user_ids: MapSet.new(), optional_integers: [], u: nil
+end
+
+defmodule TestUnion do
+  defstruct s: nil, i: nil, m: nil
 end
 
 defmodule Nesting do


### PR DESCRIPTION
This uses matching in the `serialize` definition to enforce that only unions
with zero or one field can be serialized.