### PR TITLE
More robust handling of void return types

### DIFF
--- a/lib/thrift/clients/binary_framed.ex
+++ b/lib/thrift/clients/binary_framed.ex
@@ -258,7 +258,7 @@ defmodule Thrift.Clients.BinaryFramed do
     {:error, {:exception, exc}}
   end
 
-  defp handle_message({:ok, {_, decoded_sequence_id, _, decoded_rpc_name, _}},
+  defp handle_message({:ok, {_, decoded_sequence_id, decoded_rpc_name, _}},
                       sequence_id, rpc_name, _) do
     ex = case {decoded_sequence_id, decoded_rpc_name} do
            {^sequence_id, mismatched_rpc_name} ->

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -156,18 +156,12 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         :error
       end
 
+      defp skip_struct(<<0, rest::binary>>) do
+        rest
+      end
       defp skip_struct(<<type, _id::16-signed, rest::binary>>) do
-        case skip_field(rest, type) do
-          <<0::size(8), rest::binary>> ->
-            # we have a struct stop
-            rest
-
-          <<remaining::binary>> ->
-            skip_struct(remaining)
-
-          :error ->
-            :error
-        end
+        skip_field(rest, type)
+        |> skip_struct
       end
       defp skip_struct(_) do
         :error

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -160,7 +160,8 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         rest
       end
       defp skip_struct(<<type, _id::16-signed, rest::binary>>) do
-        skip_field(rest, type)
+        rest
+        |> skip_field(type)
         |> skip_struct
       end
       defp skip_struct(_) do

--- a/test/clients/binary_framed_test.exs
+++ b/test/clients/binary_framed_test.exs
@@ -1,0 +1,63 @@
+defmodule BinaryFramedTest do
+  use ThriftTestCase
+
+  alias Thrift.Clients.BinaryFramed
+
+  @thrift_file name: "void_return.thrift", contents: """
+  service VoidReturns {
+    void my_call(1: i64 id)
+  }
+  """
+  alias BinaryFramedTest.VoidReturns
+  alias Thrift.TApplicationException, as: TAE
+
+  thrift_test "it should be able to deserialize an invalid message" do
+    msg = <<128, 1, 0, 2>>
+    assert {:error, {:cant_decode_message, ^msg}} = BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+  end
+
+  thrift_test "it should be able to read a malformed tapplicationexception" do
+    begin = Thrift.Protocols.Binary.serialize(:message_begin, {:exception, 941, "bad"})
+    msg = begin <> <<1, 1, 1, 1>>
+
+    expected_message = "Could not decode TApplicationException, remaining was <<1, 1, 1, 1>>"
+    expected_type = :protocol_error
+
+    assert {:error, {:exception, ex}} = BinaryFramed.deserialize_message_reply(msg, "bad", 941, VoidReturns.MyCallResponse)
+    assert %TAE{message: ^expected_message,
+                                         type: ^expected_type} = ex
+  end
+
+  thrift_test "it should be able to deserialize a message with a bad sequence id" do
+    msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
+
+    assert {:error, {:exception, ex}} = BinaryFramed.deserialize_message_reply(msg, "my_call", 1912, VoidReturns.MyCallResponse)
+    assert %TAE{type: :bad_sequence_id} = ex
+  end
+
+  thrift_test "it should be able to deserialize a message with the wrong method name" do
+    msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
+
+    assert {:error, {:exception, ex}} = BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+    assert %TAE{type: :wrong_method_name} = ex
+  end
+
+  thrift_test "it should be able to deserialize a message with the wrong method name and sequence id " do
+    msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
+
+    assert {:error, {:exception, ex}} = BinaryFramed.deserialize_message_reply(msg, "my_call", 1234, VoidReturns.MyCallResponse)
+    assert %TAE{type: :sequence_id_and_rpc_name_mismatched} = ex
+  end
+
+  thrift_test "It should be able to deserialize a void message" do
+    msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
+
+    assert {:ok, nil} =  BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+  end
+
+  thrift_test "It should be able to deserialize a void message with an empty struct" do
+    msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 12, 0, 0, 0, 0>>
+
+    assert {:ok, nil} =  BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+  end
+end

--- a/test/clients/binary_framed_test.exs
+++ b/test/clients/binary_framed_test.exs
@@ -8,7 +8,6 @@ defmodule BinaryFramedTest do
     void my_call(1: i64 id)
   }
   """
-  alias BinaryFramedTest.VoidReturns
   alias Thrift.TApplicationException, as: TAE
 
   thrift_test "it should be able to deserialize an invalid message" do
@@ -49,13 +48,13 @@ defmodule BinaryFramedTest do
     assert %TAE{type: :sequence_id_and_rpc_name_mismatched} = ex
   end
 
-  thrift_test "It should be able to deserialize a void message" do
+  thrift_test "it should be able to deserialize a void message" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
 
     assert {:ok, nil} =  BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
   end
 
-  thrift_test "It should be able to deserialize a void message with an empty struct" do
+  thrift_test "it should be able to deserialize a void message with an empty struct" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 12, 0, 0, 0, 0>>
 
     assert {:ok, nil} =  BinaryFramed.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)


### PR DESCRIPTION
The erlang server replies to void responses with <<12, 0, 0, 0, 0>>
which is an empty struct and the stop byte from the respone
struct. Other implementations just reply with the stop byte from the
response struct. We can now parse both.

I also fixed a bug that would occur if the sequence ids or messages
would mismatch. I added tests for all cases.