### PR TITLE
Specialize boolean field serializer

### DIFF
--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -850,6 +850,19 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     end
   end
 
+  defp field_serializer(%Field{name: name, type: :bool, id: id}, _file_group) do
+    var = Macro.var(name, nil)
+    quote do
+      case unquote(var) do
+        nil ->
+          <<>>
+        false ->
+          <<unquote(@bool), unquote(id) :: size(16), 0>>
+        _ ->
+          <<unquote(@bool), unquote(id) :: size(16), 1>>
+      end
+    end
+  end
   defp field_serializer(%Field{name: name} = field, file_group) do
     var = Macro.var(name, nil)
     quote do


### PR DESCRIPTION
It was producing a redundant case statement.

```elixir
case foo do
  nil -> <<>>
  _ ->
    [<<2, id::size(16)>>, case foo do
      nil   -> <<0>>
      false -> <<0>>
      _     -> <<1>>
    end]
end
```

The new output is simpler, both in the number of case statements and in the
structure of the iolist returned.

```elixir
case foo do
  nil   -> <<>>
  false -> <<2, id::size(16), 0>>
  _     -> <<2, id::size(16), 1>>
end
```