### PR TITLE
Improve iolist optimization

### DIFF
--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -808,7 +808,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
         quote do
           def serialize(%unquote(name){unquote_splicing(field_matchers)}) do
-            unquote([field_serializers, <<0>>] |> Utils.merge_binaries)
+            unquote([field_serializers, <<0>>] |> Utils.optimize_iolist)
           end
         end
     end)
@@ -845,7 +845,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       def serialize(%unquote(name){unquote_splicing(field_matchers)}) do
-        unquote([field_serializers, <<0>>] |> Utils.merge_binaries)
+        unquote([field_serializers, <<0>>] |> Utils.optimize_iolist)
       end
     end
   end
@@ -867,7 +867,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     [
       quote do <<unquote(type_id(type, file_group)), unquote(id) :: size(16)>> end,
       value_serializer(type, var, file_group)
-    ] |> Utils.merge_binaries |> Utils.simplify_iolist
+    ] |> Utils.optimize_iolist
   end
 
   defp value_serializer(:bool, var, _file_group) do
@@ -898,7 +898,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
           unquote([
             value_serializer(key_type, Macro.var(:k, nil), file_group),
             value_serializer(val_type, Macro.var(:v, nil), file_group),
-          ] |> Utils.merge_binaries |> Utils.simplify_iolist)
+          ] |> Utils.optimize_iolist)
         end
       ]
     end
@@ -908,7 +908,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
       [
         <<unquote(type_id(type, file_group)), MapSet.size(unquote(var)) :: size(32)>>,
         for unquote(Macro.var(:e, nil)) <- unquote(var) do
-          unquote(value_serializer(type, Macro.var(:e, nil), file_group) |> Utils.merge_binaries |> Utils.simplify_iolist)
+          unquote(value_serializer(type, Macro.var(:e, nil), file_group) |> Utils.optimize_iolist)
         end,
       ]
     end
@@ -918,7 +918,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
       [
         <<unquote(type_id(type, file_group)), length(unquote(var)) :: size(32)>>,
         for unquote(Macro.var(:e, nil)) <- unquote(var) do
-          unquote(value_serializer(type, Macro.var(:e, nil), file_group) |> Utils.merge_binaries |> Utils.simplify_iolist)
+          unquote(value_serializer(type, Macro.var(:e, nil), file_group) |> Utils.optimize_iolist)
         end,
       ]
     end

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -79,59 +79,59 @@ defmodule Thrift.Generator.Utils do
   # Optimize a quoted expression that returns an iolist. The high level strategy
   # is to flatten lists and combine adjacent binaries.
   #
-  def optimize_iolist(expr=[[a | b] | c]) do
+  def optimize_iolist([[a | b] | c] = expr) do
     debug_optimization(expr, "flatten list")
     optimize_iolist([a, b | c])
   end
-  def optimize_iolist(expr=[a, [b | c] | d]) do
+  def optimize_iolist([a, [b | c] | d] = expr) do
     debug_optimization(expr, "flatten list")
     optimize_iolist([a, b, c | d])
   end
-  def optimize_iolist(expr=[[] | a]) do
+  def optimize_iolist([[] | a] = expr) do
     debug_optimization(expr, "discard empty list")
     optimize_iolist(a)
   end
-  def optimize_iolist(expr=[a, [] | b]) do
+  def optimize_iolist([a, [] | b] = expr) do
     debug_optimization(expr, "discard empty list")
     optimize_iolist([a | b])
   end
-  def optimize_iolist(expr=[a, b, [] | c]) do
+  def optimize_iolist([a, b, [] | c] = expr) do
     debug_optimization(expr, "discard empty list")
     optimize_iolist([a, b | c])
   end
-  def optimize_iolist(expr=[{:|, _, a} | b]) do
+  def optimize_iolist([{:|, _, a} | b] = expr) do
     debug_optimization(expr, "extract final iolist cell")
     optimize_iolist([a | b])
   end
-  def optimize_iolist(expr=[a, {:|, _, b} | c]) do
+  def optimize_iolist([a, {:|, _, b} | c] = expr) do
     debug_optimization(expr, "extract final iolist cell")
     optimize_iolist([a, b | c])
   end
-  def optimize_iolist(expr=[{:<<>>, opts, a}, {:<<>>, _, b} | rest]) do
+  def optimize_iolist([{:<<>>, opts, a}, {:<<>>, _, b} | rest] = expr) do
     debug_optimization(expr, "merge binary expressions")
     optimize_iolist([{:<<>>, opts, a ++ b} | rest])
   end
-  def optimize_iolist(expr=[a, {:<<>>, opts, b} | rest]) when is_binary(a) do
+  def optimize_iolist([a, {:<<>>, opts, b} | rest] = expr) when is_binary(a) do
     debug_optimization(expr, "merge binary and binary expression")
     optimize_iolist([{:<<>>, opts, [a | b]} | rest])
   end
-  def optimize_iolist(expr=[{:<<>>, opts, a}, b | rest]) when is_binary(b) do
+  def optimize_iolist([{:<<>>, opts, a}, b | rest] = expr) when is_binary(b) do
     debug_optimization(expr, "merge binary expression and binary")
     optimize_iolist([{:<<>>, opts, a ++ [b]} | rest])
   end
-  def optimize_iolist(expr=[a, b | rest]) when is_binary(a) and is_binary(b) do
+  def optimize_iolist([a, b | rest] = expr) when is_binary(a) and is_binary(b) do
     debug_optimization(expr, "merge binaries")
     optimize_iolist([a <> b | rest])
   end
-  def optimize_iolist(expr=[a, b]) do
+  def optimize_iolist([a, b] = expr) do
     debug_optimization(expr, "final cons cell")
     [{:|, [], [a, b]}]
   end
-  def optimize_iolist(expr=[a]) do
+  def optimize_iolist([a] = expr) do
     debug_optimization(expr, "unwrap single element")
     a
   end
-  def optimize_iolist(expr=[a | rest]) do
+  def optimize_iolist([a | rest] = expr) do
     debug_optimization(expr, "skip element")
     expr = case optimize_iolist(rest) do
       b when is_list(b) -> [a | b]

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -59,48 +59,89 @@ defmodule Thrift.Generator.Utils do
     end)
   end
 
-  @doc """
-  Optimize an expression that returns an iolist.
+  # Change this to true to see iolist optimizations as they are applied.
+  @debug_optimization false
+  defmacrop debug_optimization(expr, label) do
+    if @debug_optimization do
+      quote do
+        unquote(expr) |> Macro.to_string |> IO.puts
+        IO.puts unquote(label)
+      end
+    else
+      quote do
+        _ = unquote(expr)
+      end
+    end
+  end
 
-    [<<1>>, <<2>>] => <<1, 2>>
-  """
-  def optimize_iolist([a | rest]) when is_list(a) do
-    optimize_iolist(a ++ rest)
+  @doc false
+  #
+  # Optimize a quoted expression that returns an iolist. The high level strategy
+  # is to flatten lists and combine adjacent binaries.
+  #
+  def optimize_iolist(expr=[[a | b] | c]) do
+    debug_optimization(expr, "flatten list")
+    optimize_iolist([a, b | c])
   end
-  def optimize_iolist([a, b | rest]) when is_list(b) do
-    optimize_iolist([a] ++ b ++ rest)
+  def optimize_iolist(expr=[a, [b | c] | d]) do
+    debug_optimization(expr, "flatten list")
+    optimize_iolist([a, b, c | d])
   end
-  def optimize_iolist([{:<<>>, opts, a}, {:<<>>, _, b} | rest]) do
+  def optimize_iolist(expr=[[] | a]) do
+    debug_optimization(expr, "discard empty list")
+    optimize_iolist(a)
+  end
+  def optimize_iolist(expr=[a, [] | b]) do
+    debug_optimization(expr, "discard empty list")
+    optimize_iolist([a | b])
+  end
+  def optimize_iolist(expr=[a, b, [] | c]) do
+    debug_optimization(expr, "discard empty list")
+    optimize_iolist([a, b | c])
+  end
+  def optimize_iolist(expr=[{:|, _, a} | b]) do
+    debug_optimization(expr, "extract final iolist cell")
+    optimize_iolist([a | b])
+  end
+  def optimize_iolist(expr=[a, {:|, _, b} | c]) do
+    debug_optimization(expr, "extract final iolist cell")
+    optimize_iolist([a, b | c])
+  end
+  def optimize_iolist(expr=[{:<<>>, opts, a}, {:<<>>, _, b} | rest]) do
+    debug_optimization(expr, "merge binary expressions")
     optimize_iolist([{:<<>>, opts, a ++ b} | rest])
   end
-  def optimize_iolist([a, {:<<>>, opts, b} | rest]) when is_binary(a) do
+  def optimize_iolist(expr=[a, {:<<>>, opts, b} | rest]) when is_binary(a) do
+    debug_optimization(expr, "merge binary and binary expression")
     optimize_iolist([{:<<>>, opts, [a | b]} | rest])
   end
-  def optimize_iolist([{:<<>>, opts, a}, b | rest]) when is_binary(b) do
+  def optimize_iolist(expr=[{:<<>>, opts, a}, b | rest]) when is_binary(b) do
+    debug_optimization(expr, "merge binary expression and binary")
     optimize_iolist([{:<<>>, opts, a ++ [b]} | rest])
   end
-  def optimize_iolist([{:<<>>, opts, a}, <<0>> | rest]) do
-    optimize_iolist([{:<<>>, opts, a ++ [0]} | rest])
+  def optimize_iolist(expr=[a, b | rest]) when is_binary(a) and is_binary(b) do
+    debug_optimization(expr, "merge binaries")
+    optimize_iolist([a <> b | rest])
   end
-  def optimize_iolist([{:|, _, [a, b]} | rest]) do
-    optimize_iolist([a, b | rest])
-  end
-  def optimize_iolist([a, b]) do
+  def optimize_iolist(expr=[a, b]) do
+    debug_optimization(expr, "final cons cell")
     [{:|, [], [a, b]}]
   end
-  def optimize_iolist([binary]) do
-    binary
+  def optimize_iolist(expr=[a]) do
+    debug_optimization(expr, "unwrap single element")
+    a
   end
-  def optimize_iolist([a | rest]) do
-    [optimize_iolist(a) | optimize_iolist(rest)]
+  def optimize_iolist(expr=[a | rest]) do
+    debug_optimization(expr, "skip element")
+    expr = case optimize_iolist(rest) do
+      b when is_list(b) -> [a | b]
+      b -> [a, b]
+    end
+    debug_optimization(expr, "recombined skipped element")
+    expr
   end
-  def optimize_iolist({:<<>>, _, _} = binary) do
-    binary
-  end
-  def optimize_iolist(binary) when is_binary(binary) do
-    binary
-  end
-  def optimize_iolist(other) do
-    other
+  def optimize_iolist(expr) do
+    debug_optimization(expr, "done")
+    expr
   end
 end

--- a/test/generator/utils_test.exs
+++ b/test/generator/utils_test.exs
@@ -1,11 +1,11 @@
 defmodule Thrift.Generator.UtilsTest do
-  use ThriftTestCase
+  use ExUnit.Case
   import Thrift.Generator.Utils
 
-  defmacro check(input, output) do
+  defmacro check(input, expected_output) do
     input_source = optimize_iolist(input) |> Macro.to_string
-    output_source = output |> Macro.to_string
-    assert input_source == output_source
+    expected_output_source = expected_output |> Macro.to_string
+    assert input_source == expected_output_source
   end
 
   test "optimize_iolist" do

--- a/test/generator/utils_test.exs
+++ b/test/generator/utils_test.exs
@@ -1,0 +1,23 @@
+defmodule Thrift.Generator.UtilsTest do
+  use ThriftTestCase
+  import Thrift.Generator.Utils
+
+  defmacro check(input, output) do
+    input_source = optimize_iolist(input) |> Macro.to_string
+    output_source = output |> Macro.to_string
+    assert input_source == output_source
+  end
+
+  test "optimize_iolist" do
+    check <<0>>,                  <<0>>
+    check [<<0>>],                <<0>>
+    check [<<1>>, <<2>>],         <<1, 2>>
+    check [<<1>>, [<<2>>]],       <<1, 2>>
+    check [[<<1>>], <<2>>],       <<1, 2>>
+    check [[[[<<1>>]], [<<2>>]]], <<1, 2>>
+    check [<<1>>, x, [<<2>>, y]], [<<1>>, x, <<2>> | y]
+    check [x, <<1>>, [<<2>>, y]], [x, <<1, 2>> | y]
+    check [<<1, 2>>, <<0>>],      <<1, 2, 0>>
+    check [<<1, 2>>, "foo"],      <<1, 2, "foo">>
+  end
+end


### PR DESCRIPTION
The new function `optimize_iolist` combines the old `merge_binaries` and
`simplify_iolist` functions. It also improves on them slightly, for instance by
terminating iolists with a binary instead of the empty list, and by more
consistently combining adjacent binaries.