### PR TITLE
Only build dialyxir in :dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Thrift.Mixfile do
      [{:ex_doc, "~> 0.14", only: :dev},
       {:excoveralls, "~> 0.5.7", only: [:dev, :test]},
       {:credo, "~> 0.5", only: [:dev, :test]},
-      {:dialyxir, "~> 0.4.0", only: [:dev, :test]}
+      {:dialyxir, "~> 0.4", only: :dev, runtime: false}
      ]
   end
 


### PR DESCRIPTION
Also, exclude it from the list of runtime applications because it has no
runtime component.