### PR TITLE
Use pattern matching to serialize bool values

### DIFF
--- a/lib/thrift/protocols/binary.ex
+++ b/lib/thrift/protocols/binary.ex
@@ -36,10 +36,6 @@ defmodule Thrift.Protocols.Binary do
   def int_type({:set, _}), do: 14
   def int_type({:list, _}), do: 15
 
-  defp bool_to_int(false), do: 0
-  defp bool_to_int(nil), do: 0
-  defp bool_to_int(_), do: 1
-
   defp to_message_type(:call), do: 1
   defp to_message_type(:reply), do: 2
   defp to_message_type(:exception), do: 3
@@ -54,8 +50,11 @@ defmodule Thrift.Protocols.Binary do
     []
   end
   def serialize(:bool, value) do
-    value = bool_to_int(value)
-    <<value::8-signed>>
+    case value do
+      nil   -> <<0::8-signed>>
+      false -> <<0::8-signed>>
+      _     -> <<1::8-signed>>
+    end
   end
   def serialize(:i8, value) do
     <<value::8-signed>>

--- a/lib/thrift/protocols/binary.ex
+++ b/lib/thrift/protocols/binary.ex
@@ -49,9 +49,8 @@ defmodule Thrift.Protocols.Binary do
   def serialize(_, nil) do
     []
   end
-  def serialize(:bool, nil),   do: <<0::8-signed>>
   def serialize(:bool, false), do: <<0::8-signed>>
-  def serialize(:bool, _),     do: <<1::8-signed>>
+  def serialize(:bool, true),  do: <<1::8-signed>>
   def serialize(:i8, value) do
     <<value::8-signed>>
   end

--- a/lib/thrift/protocols/binary.ex
+++ b/lib/thrift/protocols/binary.ex
@@ -49,13 +49,9 @@ defmodule Thrift.Protocols.Binary do
   def serialize(_, nil) do
     []
   end
-  def serialize(:bool, value) do
-    case value do
-      nil   -> <<0::8-signed>>
-      false -> <<0::8-signed>>
-      _     -> <<1::8-signed>>
-    end
-  end
+  def serialize(:bool, nil),   do: <<0::8-signed>>
+  def serialize(:bool, false), do: <<0::8-signed>>
+  def serialize(:bool, _),     do: <<1::8-signed>>
   def serialize(:i8, value) do
     <<value::8-signed>>
   end


### PR DESCRIPTION
This eliminates the private bool_to_int/1 function and lets us return
constant binary result values directly.

We also strictly match on just the `true` and `false` atoms.

There is a nominal performance improvement, but nothing significant.