### PR TITLE
Remove the default serialize/2 match for nil

### DIFF
--- a/lib/thrift/protocols/binary.ex
+++ b/lib/thrift/protocols/binary.ex
@@ -57,9 +57,6 @@ defmodule Thrift.Protocols.Binary do
   defp from_message_type(3), do: :exception
   defp from_message_type(4), do: :oneway
 
-  def serialize(_, nil) do
-    []
-  end
   def serialize(:bool, false), do: <<0::8-signed>>
   def serialize(:bool, true),  do: <<1::8-signed>>
   def serialize(:i8, value) do


### PR DESCRIPTION
The way we serialize `nil` is context-specific and should be handled by
the more specific type-aware clauses below.