### PR TITLE
Protocols -> Protocol in the module namespace

### DIFF
--- a/lib/thrift/clients/binary_framed.ex
+++ b/lib/thrift/clients/binary_framed.ex
@@ -10,7 +10,7 @@ defmodule Thrift.Clients.BinaryFramed do
 
 
   """
-  alias Thrift.Protocols.Binary
+  alias Thrift.Protocol.Binary
   alias Thrift.TApplicationException
 
   @immutable_tcp_opts [active: false, packet: 4, mode: :binary]

--- a/lib/thrift/generator/client.ex
+++ b/lib/thrift/generator/client.ex
@@ -14,7 +14,7 @@ defmodule Thrift.Generator.Client do
       quote do
         defmodule Client.Framed do
           alias Thrift.Clients.BinaryFramed
-          alias Thrift.Protocols.Binary
+          alias Thrift.Protocol.Binary
 
           defdelegate close(conn), to: BinaryFramed
           defdelegate connect(conn, opts), to: BinaryFramed

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -86,7 +86,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
       # data from a newer schema than our own.
       defp deserialize(<<field_type, _id::16-signed, rest::binary>>, acc) do
         rest
-        |> Thrift.Protocols.Binary.skip_field(field_type)
+        |> Thrift.Protocol.Binary.skip_field(field_type)
         |> deserialize(acc)
       end
 

--- a/lib/thrift/protocol/binary.ex
+++ b/lib/thrift/protocol/binary.ex
@@ -1,4 +1,4 @@
-defmodule Thrift.Protocols.Binary do
+defmodule Thrift.Protocol.Binary do
   @moduledoc """
   Provides a set of high-level functions for working with the Thrift binary
   protocol.
@@ -58,12 +58,10 @@ defmodule Thrift.Protocols.Binary do
 
   def serialize({:list, elem_type}, elems) when is_list(elems) do
     rest = Enum.map(elems, &serialize(elem_type, &1))
-
     [<<type_id(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
   end
   def serialize({:set, elem_type}, %MapSet{} = elems) do
     rest = Enum.map(elems, &serialize(elem_type, &1))
-
     [<<type_id(elem_type)::size(8), Enum.count(elems)::32-signed>>, rest]
   end
   def serialize({:map, {key_type, val_type}}, map) when is_map(map) do

--- a/test/clients/binary_framed_test.exs
+++ b/test/clients/binary_framed_test.exs
@@ -16,7 +16,7 @@ defmodule BinaryFramedTest do
   end
 
   thrift_test "it should be able to read a malformed tapplicationexception" do
-    begin = Thrift.Protocols.Binary.serialize(:message_begin, {:exception, 941, "bad"})
+    begin = Thrift.Protocol.Binary.serialize(:message_begin, {:exception, 941, "bad"})
     msg = begin <> <<1, 1, 1, 1>>
 
     expected_message = "Could not decode TApplicationException, remaining was <<1, 1, 1, 1>>"

--- a/test/generator/binary_protocol_test.exs
+++ b/test/generator/binary_protocol_test.exs
@@ -1,7 +1,7 @@
 defmodule Thrift.Generator.BinaryProtocolTest do
   use ThriftTestCase
 
-  alias Thrift.Protocols.Binary
+  alias Thrift.Protocol.Binary
   alias Thrift.Union.TooManyFieldsSetException
 
   def assert_serializes(%{__struct__: mod} = struct, binary) do

--- a/test/protocol/binary_test.exs
+++ b/test/protocol/binary_test.exs
@@ -2,7 +2,7 @@ defmodule BinaryProtocolTest do
   use ThriftTestCase, gen_erl: true
   use ExUnit.Case
 
-  alias Thrift.Protocols.Binary
+  alias Thrift.Protocol.Binary
 
   @moduletag :integration
 


### PR DESCRIPTION
The singular convention is more common in the Elixir ecosystem. This
matches our singular "Generator" namespace name, too.