### PR TITLE
Clean up some dialyzer warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,9 @@ defmodule Thrift.Mixfile do
      description: description(),
      package: package(),
 
+     # Dialyzer
+     dialyzer: [plt_add_deps: :transitive, plt_add_apps: [:ex_unit, :mix]],
+
      # Docs
      name: "Thrift",
      docs: [
@@ -44,7 +47,7 @@ defmodule Thrift.Mixfile do
 
   def application do
     [
-      applications: [:logger],
+      applications: [:logger, :connection],
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
-  "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
+  "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},


### PR DESCRIPTION
Mostly this was just configuring dialyzer.  The jsx version update is to
clear a dialyzer crash that the old version caused.

Most of the remaining dialyzer warnings are related to the erlang lib.  This one led me to wonder if that code in parser_utils.ex is still used - maybe it can be deleted?  There is a `test "nil nested fields get their default value" do` in binary_text.exs that is commented out that may use some of this code.

```
parser_utils.ex:155: The call erlang:iolist_to_binary(iolist_struct@1::'ok' | {_,_}) breaks the contract (IoListOrBinary) -> binary() when IoListOrBinary :: iolist() | binary()
```