### PR TITLE
Clean up public Thrift.Parser documentation

### DIFF
--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -1,8 +1,9 @@
 defmodule Thrift.Parser do
   @moduledoc """
-  This module provides functions for parsing `.thrift` files.
+  This module provides functions for parsing Thrift IDL files (`.thrift`).
   """
 
+  @typedoc "A schema path element"
   @type path_element :: String.t | atom
 
   alias Thrift.Parser.{FileGroup, FileRef, Models, ParsedFile}
@@ -11,7 +12,7 @@ defmodule Thrift.Parser do
   @doc """
   Parses a Thrift document and returns the schema that it represents.
   """
-  @spec parse(String.t) :: %Schema{}
+  @spec parse(String.t) :: Schema.t
   def parse(doc) do
     doc = String.to_char_list(doc)
 
@@ -24,9 +25,9 @@ defmodule Thrift.Parser do
   @doc """
   Parses a Thrift document and returns a component to the caller.
 
-  The part of the Thrift document that's returned is determined by
-  the `path` parameter. It works a lot like the `find_in` function,
-  which takes a map and can pull out nested pieces.
+  The part of the Thrift document that's returned is determined by the `path`
+  parameter. It works a lot like the `Kernel.get_in/2` function, which takes a
+  map and can pull out nested pieces.
 
   For example, this makes it easy to get to a service definition:
 
@@ -34,7 +35,7 @@ defmodule Thrift.Parser do
 
   Will return the "MyService" service.
   """
-  @spec parse(String.t, [path_element]) :: Models.all
+  @spec parse(String.t, [path_element, ...]) :: Models.all
   def parse(doc, path) do
     schema = parse(doc)
 
@@ -47,10 +48,12 @@ defmodule Thrift.Parser do
   end
 
   @doc """
-  Takes a path to a file and parses it, adding any includes to the
-  parsed results.
+  Parses a Thrift IDL file.
+
+  In addition to the given file, all included files are also parsed and
+  returned as part of the resulting `Thrift.Parser.FileGroup`.
   """
-  @spec parse_file(Path.t) :: %FileGroup{}
+  @spec parse_file(Path.t) :: FileGroup.t
   def parse_file(file_path) do
     parsed_file = file_path
     |> FileRef.new

--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -1,11 +1,6 @@
 defmodule Thrift.Parser.Conversions do
-  @moduledoc """
-  Conversion utilities useful for parsing Thrift.
-  """
+  @moduledoc false
 
-  @doc """
-  Ensures that the argument is an atom.
-  """
   def atomify(nil), do: nil
   def atomify(l) when is_list(l) do
     List.to_atom(l)

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -1,10 +1,13 @@
 defmodule Thrift.Parser.FileGroup do
   @moduledoc """
-  Represents a group of parsed files. When you parse a file, it might include other thrift files.
-  These files are in turn accumulated and parsed and added to this module.
-  Additionally, this module allows resolution of the names of Structs / Enums / Unions etc across
+  Represents a group of parsed files.
+  
+  When you parse a file, it might include other thrift files. These files are
+  in turn accumulated and parsed and added to this module. Additionally, this
+  module allows resolution of the names of Structs / Enums / Unions etc across
   files.
   """
+
   alias Thrift.Parser.{
     FileGroup,
     FileRef,

--- a/lib/thrift/parser/literals.ex
+++ b/lib/thrift/parser/literals.ex
@@ -1,33 +1,23 @@
 defmodule Thrift.Parser.Literals do
-  @moduledoc """
-  A module containing types for defining Thrift literals
-  Thrift literals are used when setting default values and constants.
-  """
+  @moduledoc false
+
   defmodule Primitive do
-    @moduledoc """
-    A Thrift primitive type
-    """
+    @moduledoc false
     @type t :: integer | boolean | String.t | float
   end
 
   defmodule List do
-    @moduledoc """
-    A Thrift list
-    """
+    @moduledoc false
     @type t :: [Thrift.Parser.Literals.t]
   end
 
   defmodule Map do
-    @moduledoc """
-    A Thrift map
-    """
+    @moduledoc false
     @type t :: %{Thrift.Parser.Literals.t => Thrift.Parser.Literals.t}
   end
 
   defmodule Container do
-    @moduledoc """
-    A Thrift container type
-    """
+    @moduledoc false
     @type t :: Map.t | List.t
   end
 

--- a/lib/thrift/parser/resolver.ex
+++ b/lib/thrift/parser/resolver.ex
@@ -1,10 +1,11 @@
 defmodule Thrift.Parser.Resolver do
-  @moduledoc """
-  A resolver for references.
-  During file parsing, all new generated thrift concepts flow through this resolver
-  and are added to its global database of names. At the end, the database is dumped into
-  the FileGroup so it can resolve references.
-  """
+  @moduledoc false
+
+  # A resolver for references. During file parsing, all new generated thrift
+  # concepts flow through this resolver and are added to its global database
+  # of names. At the end, the database is dumped into the FileGroup so it can
+  # resolve references.
+
   alias Thrift.Parser.ParsedFile
 
   def start_link do

--- a/lib/thrift/parser/shell.ex
+++ b/lib/thrift/parser/shell.ex
@@ -1,22 +1,14 @@
 defmodule Thrift.Parser.Shell do
-  @moduledoc """
-  Utility for writing output to the shell.
-  """
+  @moduledoc false
 
   @yellow IO.ANSI.yellow
   @red IO.ANSI.red
   @reset IO.ANSI.reset
 
-  @doc """
-  Emits a warning to the shell in a yellow color
-  """
   def warn(msg) do
     IO.puts "#{@yellow}#{msg}#{@reset}"
   end
 
-  @doc """
-  Emits an error to the shell in a red color
-  """
   def error(msg) do
     IO.puts "#{@red}#{msg}#{@reset}"
   end

--- a/lib/thrift/parser/types.ex
+++ b/lib/thrift/parser/types.ex
@@ -1,53 +1,38 @@
 defmodule Thrift.Parser.Types do
-  @moduledoc """
-  A container module for modules containing typespecs for Thrift files.
-  """
+  @moduledoc false
+
   defmodule Primitive do
-    @moduledoc """
-    Typespec for Thrift primitives
-    """
+    @moduledoc false
     @type t :: :bool | :i8 | :i16 | :i64 | :binary | :double | :byte | :string
   end
 
   defmodule Ident do
-    @moduledoc """
-    A Thrift identifier
-    """
+    @moduledoc false
     @type t :: String.t
   end
 
   defmodule Standalone do
-    @moduledoc """
-    A Thrift type that isn't a container
-    """
+    @moduledoc false
     @type t :: Ident.t | Primitive.t
   end
 
   defmodule List do
-    @moduledoc """
-    A Thrift list.
-    """
+    @moduledoc false
     @type t :: {:list, Thrift.Parser.Types.t}
   end
 
   defmodule Map do
-    @moduledoc """
-    A Thrift map
-    """
-    @type t  :: {:map, {Thrift.Parser.Types.t, Thrift.Parser.Types.t}}
+    @moduledoc false
+    @type t :: {:map, {Thrift.Parser.Types.t, Thrift.Parser.Types.t}}
   end
 
   defmodule Set do
-    @moduledoc """
-    A Thrift set
-    """
+    @moduledoc false
     @type t :: {:set, Thrift.Parser.Types.t}
   end
 
   defmodule Container do
-    @moduledoc """
-    A Thrift contianer type
-    """
+    @moduledoc false
     @type t :: List.t | Map.t | Set.t
   end
 


### PR DESCRIPTION
This primarily hides internal-only documentation but also includes some
minor doc and typespec cleanup.