### PR TITLE
Remove the Apache Thrift Erlang runtime library

### DIFF
--- a/.ebert.yml
+++ b/.ebert.yml
@@ -7,4 +7,3 @@ engines:
 exclude_paths:
 - ci
 - doc
-- ext

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/thrift"]
-	path = ext/thrift
-	url = https://github.com/apache/thrift.git

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 This package contains a handful of useful utilities for working with
 [Thrift](https://thrift.apache.org/) in Elixir.
 
-In particular, it includes a copy of the Erlang Thrift runtime library.
-
 ## Setup
 
 Start by adding this package to your project as a dependency:
@@ -20,7 +18,7 @@ Start by adding this package to your project as a dependency:
 Or to track the GitHub master branch:
 
 ```elixir
-{:thrift, github: "pinterest/elixir-thrift", submodules: true}
+{:thrift, github: "pinterest/elixir-thrift"}
 ```
 
 ## Mix

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,6 +1,5 @@
 {
   "skip_files": [
-      "ext",
       "src/thrift_lexer.erl",
       "src/thrift_parser.erl",
       "test/support"

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,6 @@ defmodule Thrift.Mixfile do
 
      # Build Environment
      erlc_paths: erlc_paths(Mix.env),
-     erlc_include_path: "ext/thrift/lib/erl/include",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:leex, :yecc, :erlang, :elixir, :app],
 
@@ -59,8 +58,8 @@ defmodule Thrift.Mixfile do
     ]
   end
 
-  defp erlc_paths(:test), do: ["src", "ext/thrift/lib/erl/src", "test/support/src"]
-  defp erlc_paths(_),     do: ["src", "ext/thrift/lib/erl/src"]
+  defp erlc_paths(:test), do: ["src", "test/support/src"]
+  defp erlc_paths(_),     do: ["src"]
 
   defp elixirc_paths(:test), do: ["lib", "test/support/lib"]
   defp elixirc_paths(_),     do: ["lib"]
@@ -80,8 +79,6 @@ defmodule Thrift.Mixfile do
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => @project_url},
       files: ~w(README.md LICENSE mix.exs lib) ++
-             ~w(ext/thrift/CHANGES ext/thrift/LICENSE ext/thrift/NOTICE) ++
-             ~w(ext/thrift/README.md ext/thrift/doc ext/thrift/lib/erl) ++
              ~w(src/thrift_lexer.xrl src/thrift_parser.yrl)
      ]
   end


### PR DESCRIPTION
We still have a copy under test/support/src/ that's used by our
integration tests, but we otherwise no longer have any need to ship a
copy of Apache Thrift Erlang runtime.