### PR TITLE
Fix main reference to the README document

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/pinterest/elixir-thrift.svg?branch=master)](https://travis-ci.org/pinterest/elixir-thrift)
 [![Coverage Status](https://coveralls.io/repos/pinterest/elixir-thrift/badge.svg?branch=master&service=github)](https://coveralls.io/github/pinterest/elixir-thrift?branch=master)
-![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
 
 This package contains a handful of useful utilities for working with
 [Thrift](https://thrift.apache.org/) in Elixir.

--- a/mix.exs
+++ b/mix.exs
@@ -45,9 +45,8 @@ defmodule Thrift.Mixfile do
      # Docs
      name: "Thrift",
      docs: [
-       main: "readme",
+       main: "README",
        extras: ["README.md": [group: "Documents", title: "README"]],
-       extra_section: "Overview",
        source_ref: "thrift_tng",
        source_url: @project_url]]
   end


### PR DESCRIPTION
This appears to be case-sensitive, and I wasn't noticing because the
macOS's file system isn't.

Also, remove the Apache License batch from the README because it doesn't
render that well as part of the generated documentation. We may want to
remove the other badges later too if we continue to use the README as a
key part of our Hex-published docs.