### PR TITLE
Require string for StructGenerator.generate label

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -74,21 +74,21 @@ defmodule Thrift.Generator do
   defp generate_struct_modules(schema) do
     for {_, struct} <- schema.structs do
       full_name = FileGroup.dest_module(schema.file_group, struct)
-      {full_name, StructGenerator.generate("struct", schema, full_name, struct)}
+      {full_name, StructGenerator.generate(:struct, schema, full_name, struct)}
     end
   end
 
   defp generate_union_modules(schema) do
     for {_, union} <- schema.unions do
       full_name = FileGroup.dest_module(schema.file_group, union)
-      {full_name, StructGenerator.generate("union", schema, full_name, union)}
+      {full_name, StructGenerator.generate(:union, schema, full_name, union)}
     end
   end
 
   defp generate_exception_modules(schema) do
     for {_, exception} <- schema.exceptions do
       full_name = FileGroup.dest_module(schema.file_group, exception)
-      {full_name, StructGenerator.generate("exception", schema, full_name, exception)}
+      {full_name, StructGenerator.generate(:exception, schema, full_name, exception)}
     end
   end
 

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -39,7 +39,7 @@ defmodule Thrift.Generator.Service do
 
     struct = Struct.new(Atom.to_char_list(arg_module_name), function.params)
 
-    StructGenerator.generate("struct", schema, struct.name, struct)
+    StructGenerator.generate(:struct, schema, struct.name, struct)
   end
 
   def generate_response_struct(schema, function) do
@@ -56,7 +56,7 @@ defmodule Thrift.Generator.Service do
     response_module_name = service_module_name(function, :response)
     response_struct = Struct.new(Atom.to_char_list(response_module_name), fields)
 
-    StructGenerator.generate("struct", schema, response_struct.name, response_struct)
+    StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
   end
 
   def service_module_name(%Function{} = function, suffix) do

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -39,7 +39,7 @@ defmodule Thrift.Generator.Service do
 
     struct = Struct.new(Atom.to_char_list(arg_module_name), function.params)
 
-    StructGenerator.generate(:struct, schema, struct.name, struct)
+    StructGenerator.generate("struct", schema, struct.name, struct)
   end
 
   def generate_response_struct(schema, function) do
@@ -56,7 +56,7 @@ defmodule Thrift.Generator.Service do
     response_module_name = service_module_name(function, :response)
     response_struct = Struct.new(Atom.to_char_list(response_module_name), fields)
 
-    StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
+    StructGenerator.generate("struct", schema, response_struct.name, response_struct)
   end
 
   def service_module_name(%Function{} = function, suffix) do

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -3,7 +3,7 @@ defmodule Thrift.Generator.StructGenerator do
   alias Thrift.Generator.Utils
   alias Thrift.Parser.FileGroup
 
-  def generate(label, schema, name, struct) do
+  def generate(label, schema, name, struct) when label in ["struct", "union", "exception"] do
     struct_parts = Enum.map(struct.fields, fn
       %{name: name, default: nil, type: type} ->
         {name, zero(schema, type)}
@@ -18,10 +18,13 @@ defmodule Thrift.Generator.StructGenerator do
     |> Utils.merge_blocks
     |> Utils.sort_defs
 
-    define_block = if label in ["exception", :exception] do
-      quote do: defexception unquote(struct_parts)
-    else
-      quote do: defstruct unquote(struct_parts)
+    define_block = case label do
+      "struct" ->
+        quote do: defstruct unquote(struct_parts)
+      "union" ->
+        quote do: defstruct unquote(struct_parts)
+      "exception" ->
+        quote do: defexception unquote(struct_parts)
     end
 
     quote do

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -3,7 +3,7 @@ defmodule Thrift.Generator.StructGenerator do
   alias Thrift.Generator.Utils
   alias Thrift.Parser.FileGroup
 
-  def generate(label, schema, name, struct) when label in ["struct", "union", "exception"] do
+  def generate(label, schema, name, struct) when label in [:struct, :union, :exception] do
     struct_parts = Enum.map(struct.fields, fn
       %{name: name, default: nil, type: type} ->
         {name, zero(schema, type)}
@@ -19,11 +19,11 @@ defmodule Thrift.Generator.StructGenerator do
     |> Utils.sort_defs
 
     define_block = case label do
-      "struct" ->
+      :struct ->
         quote do: defstruct unquote(struct_parts)
-      "union" ->
+      :union ->
         quote do: defstruct unquote(struct_parts)
-      "exception" ->
+      :exception ->
         quote do: defexception unquote(struct_parts)
     end
 


### PR DESCRIPTION
Previously its argument type was inconsistent, being sometimes a string and
other times an atom.