### PR TITLE
Bump our minimum Elixir version to 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
 elixir: 1.3.4
-otp_release: 19.2
+otp_release: 18.2
 matrix:
   include:
-    - elixir: 1.2.6
-      otp_release: 18.2
+    - elixir: 1.4.0-rc.1
+      otp_release: 19.2
 sudo: required
 dist: trusty
 services: docker

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Thrift.Mixfile do
   def project do
     [app: :thrift,
      version: @version,
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      deps: deps(),
 
      # Build Environment


### PR DESCRIPTION
This gives us the ability to use 1.3+ APIs as we develop our 2.0 branch.
Many other libraries (Absinthe, Dialyxir) also have a 1.3+ requirement.

Also, Elixir 1.4 is imminent, so add that to our testing matrix too.