### PR TITLE
Handle empty and non-empty default containers

### DIFF
--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -7,8 +7,9 @@ defmodule Thrift.Generator.StructGenerator do
     struct_parts = Enum.map(struct.fields, fn
       %{name: name, default: nil, type: type} ->
         {name, zero(schema, type)}
-      %{name: name, default: %MapSet{}} ->
-        {name, quote do: MapSet.new()}
+      %{name: name, default: %MapSet{map: m}} ->
+        values = Map.keys(m)
+        {name, quote do: MapSet.new(unquote(values))}
       %{name: name, default: default} when not is_nil(default) ->
         {name, default}
     end)

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -7,6 +7,8 @@ defmodule Thrift.Generator.StructGenerator do
     struct_parts = Enum.map(struct.fields, fn
       %{name: name, default: nil, type: type} ->
         {name, zero(schema, type)}
+      %{name: name, default: %MapSet{}} ->
+        {name, quote do: MapSet.new()}
       %{name: name, default: default} when not is_nil(default) ->
         {name, default}
     end)
@@ -65,7 +67,7 @@ defmodule Thrift.Generator.StructGenerator do
   defp zero(_schema, :binary), do: nil
   defp zero(_schema, {:map, _}), do: nil
   defp zero(_schema, {:list, _}), do: nil
-  defp zero(_schema, {:set, _}), do: quote do: nil
+  defp zero(_schema, {:set, _}), do: nil
   defp zero(_schema, %{values: [{_, value} | _]}), do: value
   defp zero(_schema, %Thrift.Parser.Models.Struct{}), do: nil
   defp zero(_schema, %Thrift.Parser.Models.Exception{}), do: nil

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -119,7 +119,6 @@ constant_def ->
 ns_name -> '*': "*".
 ns_name -> ident: unwrap('$1').
 
-
 %% JS Style mapping "foo": 32
 mapping -> literal ':' literal: {'$1', '$3'}.
 mappings -> '$empty': [].
@@ -138,6 +137,7 @@ literal -> double: unwrap('$1').
 literal -> string: unwrap('$1').
 literal -> '{' literal_list '}': '$2'.
 literal -> '{' mappings '}': '$2'.
+literal -> '[' ']' : [].
 literal -> '[' literal_list ']': '$2'.
 
 field_sep -> '$empty': nil.

--- a/test/generator/models_test.exs
+++ b/test/generator/models_test.exs
@@ -162,7 +162,7 @@ defmodule Thrift.Generator.ModelsTest do
     assert thang.numbers == MapSet.new([1, 2, 3])
   end
 
-  @thrift_file name: "empty_list.thrift", contents: """
+  @thrift_file name: "empty_container.thrift", contents: """
   struct Goth {
     1: optional list<i32> empty_like_my_soul = []
     2: optional set<i32> the_abyss = []
@@ -175,5 +175,20 @@ defmodule Thrift.Generator.ModelsTest do
     assert goth.empty_like_my_soul == []
     assert goth.the_abyss == MapSet.new
     assert goth.going_nowhere == %{}
+  end
+
+  @thrift_file name: "nonempty_container.thrift", contents: """
+  struct Cargo {
+    1: optional list<i32> fib = [1, 1, 2, 3, 5]
+    2: optional set<i32> answers = [42]
+    3: optional map<i32, string> bad_approximations = {3: "pi"}
+  }
+  """
+
+  thrift_test "containers can have non-empty defaults" do
+    cargo = %Cargo{}
+    assert cargo.fib == [1, 1, 2, 3, 5]
+    assert cargo.answers == MapSet.new([42])
+    assert cargo.bad_approximations == %{3 => "pi"}
   end
 end

--- a/test/generator/models_test.exs
+++ b/test/generator/models_test.exs
@@ -161,4 +161,19 @@ defmodule Thrift.Generator.ModelsTest do
     thang = %Thangs{numbers: MapSet.new([1, 2, 3])}
     assert thang.numbers == MapSet.new([1, 2, 3])
   end
+
+  @thrift_file name: "empty_list.thrift", contents: """
+  struct Goth {
+    1: optional list<i32> empty_like_my_soul = []
+    2: optional set<i32> the_abyss = []
+    3: optional map<i32, string> going_nowhere = {}
+  }
+  """
+
+  thrift_test "containers can have empty defaults" do
+    goth = %Goth{}
+    assert goth.empty_like_my_soul == []
+    assert goth.the_abyss == MapSet.new
+    assert goth.going_nowhere == %{}
+  end
 end


### PR DESCRIPTION
Fixes #134 and also handles the non-empty set case

I'm not thrilled with the way I handled `struct_generator.ex` - it seems like there should be a more generic way to handle complex default values.  The way it was before, the generated code was `defstruct(...., set_field: #MapSet<[]>, ...)` - i.e., it was the `inspect` string for a mapset which was causing everything after `#` to be interpreted as a comment.

I think default structs may have the same problem, but I wanted to handle that in a separate PR.