### PR TITLE
Rename service_module_name/2 to just module_name/2

### DIFF
--- a/lib/thrift/generator/client/binary_framed.ex
+++ b/lib/thrift/generator/client/binary_framed.ex
@@ -28,9 +28,9 @@ defmodule Thrift.Generator.Client.BinaryFramed do
 
   defp generate_handler_function(service_module, function) do
     args_module = service_module
-    |> Module.concat(Service.service_module_name(function, :args))
+    |> Module.concat(Service.module_name(function, :args))
 
-    response_module = Service.service_module_name(function, :response)
+    response_module = Service.module_name(function, :response)
 
     underscored_name = function.name
     |> Atom.to_string

--- a/lib/thrift/generator/server/binary_framed.ex
+++ b/lib/thrift/generator/server/binary_framed.ex
@@ -33,7 +33,7 @@ defmodule Thrift.Generator.Server.BinaryFramed do
     fn_name = Atom.to_string(function.name)
     handler_fn_name = Utils.underscore(function.name)
     response_module = service_module
-    |> Module.concat(Service.service_module_name(function, :response))
+    |> Module.concat(Service.module_name(function, :response))
 
     handler = quote do
       rsp = handler_module.unquote(handler_fn_name)()
@@ -50,10 +50,10 @@ defmodule Thrift.Generator.Server.BinaryFramed do
   def generate_handler_function(file_group, service_module, function) do
     fn_name = Atom.to_string(function.name)
     args_module = service_module
-    |> Module.concat(Service.service_module_name(function, :args))
+    |> Module.concat(Service.module_name(function, :args))
 
     response_module = service_module
-    |> Module.concat(Service.service_module_name(function, :response))
+    |> Module.concat(Service.module_name(function, :response))
 
     struct_matches = function.params
     |> Enum.map(fn param ->

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -38,7 +38,7 @@ defmodule Thrift.Generator.Service do
   end
 
   def generate_args_struct(schema, function) do
-    arg_module_name = service_module_name(function, :args)
+    arg_module_name = module_name(function, :args)
 
     struct = Struct.new(Atom.to_char_list(arg_module_name), function.params)
 
@@ -56,13 +56,13 @@ defmodule Thrift.Generator.Service do
 
     fields = [success | exceptions]
 
-    response_module_name = service_module_name(function, :response)
+    response_module_name = module_name(function, :response)
     response_struct = Struct.new(Atom.to_char_list(response_module_name), fields)
 
     StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
   end
 
-  def service_module_name(%Function{} = function, suffix) do
+  def module_name(%Function{} = function, suffix) do
     struct_name = "#{function.name}_#{suffix}"
     |> Macro.camelize
     |> String.to_atom


### PR DESCRIPTION
This avoids a bit of "stutter" because we always call this function via
the Service module namespace (e.g. `Service.module_name`).