### PR TITLE
Booleans can have integer default values

### DIFF
--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -19,6 +19,9 @@ defmodule Thrift.Parser.Conversions do
     val
   end
 
+  def cast(:bool, 0), do: false
+  def cast(:bool, 1), do: true
+
   def cast(:string, val) do
     List.to_string(val)
   end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -380,6 +380,8 @@ defmodule ParserTest do
     struct MyStruct {
       1: optional bool negative;
       2: optional bool positive = true;
+      3: optional bool c_positive = 1;
+      4: optional bool c_negative = 0;
     }
     """
     |> parse([:structs, :MyStruct])
@@ -388,7 +390,9 @@ defmodule ParserTest do
       name: :MyStruct,
       fields: [
         %Field{id: 1, name: :negative, type: :bool, required: false, default: nil},
-        %Field{id: 2, name: :positive, type: :bool, required: false, default: true}
+        %Field{id: 2, name: :positive, type: :bool, required: false, default: true},
+        %Field{id: 3, name: :c_positive, type: :bool, required: false, default: true},
+        %Field{id: 4, name: :c_negative, type: :bool, required: false, default: false},
       ]}
   end
 


### PR DESCRIPTION
Booleans can have 1 and 0 as default values. This converts them into
true and false, so we can deal with them properly.

Fixes #142