### PR TITLE
Generate const default values

### DIFF
--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -2,16 +2,20 @@ defmodule Thrift.Generator.StructGenerator do
   alias Thrift.Generator.StructBinaryProtocol
   alias Thrift.Generator.Utils
   alias Thrift.Parser.FileGroup
+  alias Thrift.Parser.Models.{
+    Constant,
+    Exception,
+    Field,
+    Struct,
+    StructRef,
+    TEnum,
+    Union
+  }
 
   def generate(label, schema, name, struct) when label in [:struct, :union, :exception] do
     struct_parts = Enum.map(struct.fields, fn
-      %{name: name, default: nil, type: type} ->
-        {name, zero(schema, type)}
-      %{name: name, default: %MapSet{map: m}} ->
-        values = Map.keys(m)
-        {name, quote do: MapSet.new(unquote(values))}
-      %{name: name, default: default} when not is_nil(default) ->
-        {name, default}
+      %Field{name: name, type: type, default: default} ->
+        {name, default_value(default, type, schema)}
     end)
 
     binary_protocol_defs = [
@@ -56,45 +60,50 @@ defmodule Thrift.Generator.StructGenerator do
     end
   end
 
-  # Zero values for built-in types
-  defp zero(_schema, :bool), do: nil
-  defp zero(_schema, :byte), do: nil
-  defp zero(_schema, :i8), do: nil
-  defp zero(_schema, :i16), do: nil
-  defp zero(_schema, :i32), do: nil
-  defp zero(_schema, :i64), do: nil
-  defp zero(_schema, :double), do: nil
-  defp zero(_schema, :string), do: nil
-  defp zero(_schema, :binary), do: nil
-  defp zero(_schema, {:map, _}), do: nil
-  defp zero(_schema, {:list, _}), do: nil
-  defp zero(_schema, {:set, _}), do: nil
-  defp zero(_schema, %{values: [{_, value} | _]}), do: value
-  defp zero(_schema, %Thrift.Parser.Models.Struct{}), do: nil
-  defp zero(_schema, %Thrift.Parser.Models.Exception{}), do: nil
-  defp zero(_schema, %Thrift.Parser.Models.Union{}), do: nil
-  defp zero(_schema, :void), do: nil
-
-  # Zero values for user defined types
-  defp zero(schema, %{referenced_type: type} = ref) do
-    cond do
-      # Local references
-      Map.has_key?(schema.enums, type) ->
-        zero(schema, schema.enums[type])
-      Map.has_key?(schema.typedefs, type) ->
-        zero(schema, schema.typedefs[type])
-      Map.has_key?(schema.structs, type) ->
-        quote do: nil
-
-      # Included references
-      true ->
-        case FileGroup.resolve(schema.file_group, ref) do
-          nil ->
-            raise "Unknown type: #{inspect type}"
-          thing ->
-            zero(schema, thing)
-        end
+  defp default_value(%StructRef{} = ref, type, schema) do
+    value = FileGroup.resolve(schema.file_group, ref)
+    default_value(value, type, schema)
+  end
+  defp default_value(value, %StructRef{} = ref, schema) do
+    type = FileGroup.resolve(schema.file_group, ref)
+    default_value(value, type, schema)
+  end
+  defp default_value(%Constant{type: type, value: value}, type, schema) do
+    default_value(value, type, schema)
+  end
+  defp default_value(nil, %TEnum{values: [{_, value} | _]}, _schema) do
+    value
+  end
+  defp default_value(nil, _type, _schema) do
+    nil
+  end
+  defp default_value(value, :bool, _schema) when is_boolean(value), do: value
+  defp default_value(value, :byte, _schema) when is_integer(value), do: value
+  defp default_value(value, :double, _schema) when is_float(value), do: value
+  defp default_value(value, :i8, _schema) when is_integer(value), do: value
+  defp default_value(value, :i16, _schema) when is_integer(value), do: value
+  defp default_value(value, :i32, _schema) when is_integer(value), do: value
+  defp default_value(value, :i64, _schema) when is_integer(value), do: value
+  defp default_value(value, :string, _schema) when is_binary(value), do: value
+  defp default_value(value, :string, _schema) when is_list(value) do
+    List.to_string(value)
+  end
+  defp default_value(%{} = value, {:map, {key_type, value_type}}, schema) do
+    Map.new(value, fn {key, value} ->
+      {
+        default_value(key, key_type, schema),
+        default_value(value, value_type, schema),
+      }
+    end)
+  end
+  defp default_value(%MapSet{} = set, {:set, type}, schema) do
+    values = Enum.map(set, &default_value(&1, type, schema))
+    quote do
+      MapSet.new(unquote(values))
     end
+  end
+  defp default_value(list, {:list, type}, schema) when is_list(list) do
+    Enum.map(list, &default_value(&1, type, schema))
   end
 
   def to_thrift(base_type, _file_group) when is_atom(base_type) do
@@ -109,19 +118,19 @@ defmodule Thrift.Generator.StructGenerator do
   def to_thrift({:list, element_type}, file_group) do
     "list<#{to_thrift element_type, file_group}>"
   end
-  def to_thrift(%Thrift.Parser.Models.TEnum{name: name}, _file_group) do
+  def to_thrift(%TEnum{name: name}, _file_group) do
     "#{name}"
   end
-  def to_thrift(%Thrift.Parser.Models.Struct{name: name}, _file_group) do
+  def to_thrift(%Struct{name: name}, _file_group) do
     "#{name}"
   end
-  def to_thrift(%Thrift.Parser.Models.Exception{name: name}, _file_group) do
+  def to_thrift(%Exception{name: name}, _file_group) do
     "#{name}"
   end
-  def to_thrift(%Thrift.Parser.Models.Union{name: name}, _file_group) do
+  def to_thrift(%Union{name: name}, _file_group) do
     "#{name}"
   end
-  def to_thrift(%Thrift.Parser.Models.StructRef{referenced_type: type}, file_group) do
+  def to_thrift(%StructRef{referenced_type: type}, file_group) do
     FileGroup.resolve(file_group, type) |> to_thrift(file_group)
   end
 end

--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -10,9 +10,9 @@ defmodule Thrift.Parser.Conversions do
     nil
   end
 
-  def cast(type, %{} = val) do
-    # this is for TEnumValues
-    %{val | type: type}
+  # We can't match a StructRef because it would create a circular dependency.
+  def cast(_, %{referenced_type: _} = ref) do
+    ref
   end
 
   def cast(:double, val) do
@@ -22,7 +22,7 @@ defmodule Thrift.Parser.Conversions do
   def cast(:bool, 0), do: false
   def cast(:bool, 1), do: true
 
-  def cast(:string, val) do
+  def cast(:string, val) when is_list(val) do
     List.to_string(val)
   end
 

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -88,29 +88,6 @@ defmodule Thrift.Parser.Models do
     end
   end
 
-  defmodule TEnumValue do
-    @moduledoc """
-    A reference to an enum value
-    For example, in a constant or default value.
-
-       const string DEFAULT_WEATHER = Weather.SUNNY;
-   """
-    @type t :: %TEnumValue{enum_name: atom, enum_value: atom, type: atom}
-    defstruct enum_name: nil, enum_value: nil, type: nil
-
-    import Thrift.Parser.Conversions
-
-    @spec new(char_list) :: %TEnumValue{}
-    def new(enum_value) do
-      [enum_name, enum_value] = enum_value
-      |> List.to_string
-      |> String.split(".")
-      |> Enum.map(&String.to_atom/1)
-
-      %TEnumValue{enum_name: enum_name, enum_value: enum_value}
-    end
-  end
-
   defmodule Field do
     @moduledoc """
     A Thrift field.

--- a/lib/thrift/parser/resolver.ex
+++ b/lib/thrift/parser/resolver.ex
@@ -19,6 +19,7 @@ defmodule Thrift.Parser.Resolver do
   def add(pid, %ParsedFile{} = f) do
     Agent.update(pid, fn(state) ->
       state
+      |> update(f.name, f.schema.constants)
       |> update(f.name, f.schema.services)
       |> update(f.name, f.schema.structs)
       |> update(f.name, f.schema.exceptions)

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -129,7 +129,7 @@ mappings -> mapping ',' mappings: ['$1'] ++ '$3'.
 literal_list -> literal: ['$1'].
 literal_list -> literal ',' literal_list: ['$1'] ++ '$3'.
 
-literal -> ident: 'Elixir.Thrift.Parser.Models.TEnumValue':new(unwrap('$1')).
+literal -> ident: 'Elixir.Thrift.Parser.Models.StructRef':new(unwrap('$1')).
 literal -> true: unwrap('$1').
 literal -> false: unwrap('$1').
 literal -> int: unwrap('$1').

--- a/test/generator/binary_protocol_test.exs
+++ b/test/generator/binary_protocol_test.exs
@@ -397,4 +397,51 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert_serializes %OptionalField{},                 <<0>>
     assert_serializes %OptionalField{val: 123},         <<3, 0, 1, 123, 0>>
   end
+
+  @thrift_file name: "const.thrift", contents: """
+  struct ConstStructVal {
+    1: byte num
+  }
+
+  const bool ConstBool = true
+  const byte ConstByte = 5
+  const double ConstDouble = 5.0
+  const i16 ConstI16 = 5
+  const i32 ConstI32 = 5
+  const i64 ConstI64 = 5
+  const string ConstString = "abc123"
+  const ConstStructVal ConstStruct = {"num": 5}
+  const map<string, byte> ConstMap = {"a": 1, "b": 2}
+  const set<string> ConstSet = ["a", "b"]
+  const list<string> ConstList = ["a", "b"]
+
+  struct ConstStruct {
+    1: bool bool_val = ConstBool,
+    2: byte byte_val = ConstByte,
+    3: double double_val = ConstDouble,
+    4: i16 i16_val = ConstI16,
+    5: i32 i32_val = ConstI32,
+    6: i64 i64_val = ConstI64,
+    7: string string_val = ConstString,
+    # 8: ConstStructVal struct_val = ConstStruct,
+    13: map<string, byte> map_val = ConstMap,
+    14: set<string> set_val = ConstSet,
+    15: list<string> list_val = ConstList,
+  }
+  """
+
+  thrift_test "test..." do
+    struct = %ConstStruct{}
+    assert struct.bool_val == true
+    assert struct.byte_val == 5
+    assert struct.double_val == 5.0
+    assert struct.i16_val == 5
+    assert struct.i32_val == 5
+    assert struct.i64_val == 5
+    assert struct.string_val == "abc123"
+    assert struct.map_val == %{"a" => 1, "b" => 2}
+    assert struct.set_val == MapSet.new(["a", "b"])
+    assert struct.list_val == ["a", "b"]
+    :ok
+  end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -15,7 +15,6 @@ defmodule ParserTest do
   alias Thrift.Parser.Models.Struct
   alias Thrift.Parser.Models.StructRef
   alias Thrift.Parser.Models.TEnum
-  alias Thrift.Parser.Models.TEnumValue
   alias Thrift.Parser.Models.Union
 
   import ExUnit.CaptureIO
@@ -180,7 +179,7 @@ defmodule ParserTest do
 
     assert constant == %Constant{
       name: :SUNNY,
-      value: %TEnumValue{enum_name: :Weather, enum_value: :SUNNY, type: :string},
+      value: %StructRef{referenced_type: :"Weather.SUNNY"},
       type: :string}
   end
 
@@ -199,10 +198,10 @@ defmodule ParserTest do
       name: :WEATHER_TYPES,
       type: {:list, :string},
       value: [
-        %TEnumValue{enum_name: :Weather, enum_value: :SUNNY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :CLOUDY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :RAINY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :SNOWY, type: :string},
+        %StructRef{referenced_type: :"Weather.SUNNY"},
+        %StructRef{referenced_type: :"Weather.CLOUDY"},
+        %StructRef{referenced_type: :"Weather.RAINY"},
+        %StructRef{referenced_type: :"Weather.SNOWY"},
       ]}
   end
 
@@ -221,10 +220,10 @@ defmodule ParserTest do
       name: :WEATHER_TYPES,
       type: {:set, :string},
       value: MapSet.new([
-        %TEnumValue{enum_name: :Weather, enum_value: :SUNNY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :CLOUDY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :RAINY, type: :string},
-        %TEnumValue{enum_name: :Weather, enum_value: :SNOWY, type: :string},
+        %StructRef{referenced_type: :"Weather.SUNNY"},
+        %StructRef{referenced_type: :"Weather.CLOUDY"},
+        %StructRef{referenced_type: :"Weather.RAINY"},
+        %StructRef{referenced_type: :"Weather.SNOWY"},
       ])}
   end
 
@@ -243,25 +242,10 @@ defmodule ParserTest do
       name: :weather_messages,
       type: {:map, {%StructRef{referenced_type: :Weather}, :string}},
       value: %{
-        %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :CLOUDY,
-          type: %StructRef{referenced_type: :Weather}} => "Welcome to Cleveland!",
-
-        %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :RAINY,
-          type: %StructRef{referenced_type: :Weather}} => "Welcome to Seattle!",
-
-        %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :SNOWY,
-          type: %StructRef{referenced_type: :Weather}} => "Welcome to Canada!",
-
-        %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :SUNNY,
-          type: %StructRef{referenced_type: :Weather}} => "Yay, it's sunny!"}}
+        %StructRef{referenced_type: :"Weather.CLOUDY"} => "Welcome to Cleveland!",
+        %StructRef{referenced_type: :"Weather.RAINY"} => "Welcome to Seattle!",
+        %StructRef{referenced_type: :"Weather.SNOWY"} => "Welcome to Canada!",
+        %StructRef{referenced_type: :"Weather.SUNNY"} => "Yay, it's sunny!"}}
   end
 
   test "parsing a map constant with enum values as values" do
@@ -279,25 +263,10 @@ defmodule ParserTest do
       name: :clothes_to_wear,
       type: {:map, {:string, %StructRef{referenced_type: :Weather}}},
       value: %{
-        "gloves" => %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :SNOWY,
-          type: %StructRef{referenced_type: :Weather}},
-
-        "sunglasses" => %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :SUNNY,
-          type: %StructRef{referenced_type: :Weather}},
-
-        "sweater" => %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :CLOUDY,
-          type: %StructRef{referenced_type: :Weather}},
-
-        "umbrella" => %TEnumValue{
-          enum_name: :Weather,
-          enum_value: :RAINY,
-          type: %StructRef{referenced_type: :Weather}}}}
+        "gloves" => %StructRef{referenced_type: :"Weather.SNOWY"},
+        "umbrella" => %StructRef{referenced_type: :"Weather.RAINY"},
+        "sweater" => %StructRef{referenced_type: :"Weather.CLOUDY"},
+        "sunglasses" => %StructRef{referenced_type: :"Weather.SUNNY"}}}
   end
 
   test "parsing an enum" do


### PR DESCRIPTION
Previously when the parser found a reference where it expected a static value,
it treated it as an enum. However it could also be a const. Now the parser
turns any reference into a StructRef and leaves it to the next layer to resolve
the reference.

Fixes #140.