### PR TITLE
Implement deserialization of maps/sets/lists of binaries

### DIFF
--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -310,6 +310,9 @@ defmodule Thrift.Generator.StructBinaryProtocol do
       end
     end
   end
+  defp map_key_deserializer(:binary, key_name, value_name, file_group) do
+    map_key_deserializer(:string, key_name, value_name, file_group)
+  end
   defp map_key_deserializer(:string, key_name, value_name, _file_group) do
     quote do
       defp unquote(key_name)(<<string_size::32-signed, key::binary-size(string_size), rest::binary>>, stack) do
@@ -455,6 +458,9 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
       end
     end
+  end
+  defp map_value_deserializer(:binary, key_name, value_name, file_group) do
+    map_value_deserializer(:string, key_name, value_name, file_group)
   end
   defp map_value_deserializer(:string, key_name, value_name, _file_group) do
     quote do
@@ -604,6 +610,9 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         unquote(name)(rest, [[element | list], remaining - 1 | stack])
       end
     end
+  end
+  defp list_deserializer(:binary, name, file_group) do
+    list_deserializer(:string, name, file_group)
   end
   defp list_deserializer(:string, name, _file_group) do
     quote do

--- a/test/generator/binary_protocol_test.exs
+++ b/test/generator/binary_protocol_test.exs
@@ -197,6 +197,28 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert_serializes %String{val_list: ["abc", "def"]},      <<15, 0, 4, 11, 0, 0, 0, 2, 0, 0, 0, 3, "abc", 0, 0, 0, 3, "def", 0>>
   end
 
+  @thrift_file name: "binary.thrift", contents: """
+  struct BinaryStruct {
+    1: optional binary val;
+    2: optional map<binary, binary> val_map;
+    3: optional set<binary> val_set;
+    4: optional list<binary> val_list;
+  }
+  """
+
+  thrift_test "binary serialization" do
+    assert_serializes %BinaryStruct{},                              <<0>>
+    assert_serializes %BinaryStruct{val: ""},                       <<11, 0, 1, 0, 0, 0, 0, 0>>
+    assert_serializes %BinaryStruct{val: "abc"},                    <<11, 0, 1, 0, 0, 0, 3, "abc", 0>>
+    assert_serializes %BinaryStruct{val_map: %{}},                  <<13, 0, 2, 11, 11, 0, 0, 0, 0, 0>>
+    assert_serializes %BinaryStruct{val_map: %{"abc" => "def"}},    <<13, 0, 2, 11, 11, 0, 0, 0, 1, 0, 0, 0, 3, "abc", 0, 0, 0, 3, "def", 0>>
+    assert_serializes %BinaryStruct{val_set: MapSet.new},           <<14, 0, 3, 11, 0, 0, 0, 0, 0>>
+    assert_serializes %BinaryStruct{val_set: MapSet.new(["abc"])},  <<14, 0, 3, 11, 0, 0, 0, 1, 0, 0, 0, 3, "abc", 0>>
+    assert_serializes %BinaryStruct{val_list: []},                  <<15, 0, 4, 11, 0, 0, 0, 0, 0>>
+    assert_serializes %BinaryStruct{val_list: ["abc"]},             <<15, 0, 4, 11, 0, 0, 0, 1, 0, 0, 0, 3, "abc", 0>>
+    assert_serializes %BinaryStruct{val_list: ["abc", "def"]},      <<15, 0, 4, 11, 0, 0, 0, 2, 0, 0, 0, 3, "abc", 0, 0, 0, 3, "def", 0>>
+  end
+
   @thrift_file name: "struct.thrift", contents: """
   struct Val {
     99: optional byte num;


### PR DESCRIPTION
Seems to have been overlooked. We implemented strings, which are effectively
the same in Elixir, but didn't check specifically for a type of :binary in
every situation.