### PR TITLE
Refactor Client generated/static interface

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -248,8 +248,11 @@ defmodule Thrift.Binary.Framed.Client do
     exception = Binary.deserialize(:application_exception, serialized_response)
     {:error, {:exception, exception}}
   end
-  defp handle_message({:ok, {_type, seq_id, rpc_name, _}}, seq_id, rpc_name) do
-    raise "message type"
+  defp handle_message({:ok, {message_type, seq_id, rpc_name, _}}, seq_id, rpc_name) do
+    exception = %TApplicationException{
+      message: "The server replied with invalid message type #{message_type}",
+      type: :invalid_message_type}
+    {:error, {:exception, exception}}
   end
   defp handle_message({:ok, {_, seq_id, mismatched_rpc_name, _}}, seq_id, rpc_name) do
     exception = %TApplicationException{

--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -9,6 +9,7 @@ defmodule Thrift.Generator.Binary.Framed.Client do
     functions = service.functions
     |> Map.values
     |> Enum.map(&generate_handler_function(service_module, &1))
+    |> Utils.merge_blocks
 
     quote do
       defmodule Binary.Framed.Client do
@@ -22,7 +23,7 @@ defmodule Thrift.Generator.Binary.Framed.Client do
         def start_link(host, port, opts) do
           ClientImpl.start_link(host, port, opts)
         end
-        unquote_splicing(functions |> Utils.merge_blocks)
+        unquote_splicing(functions)
       end
     end
   end

--- a/test/binary/framed/client_test.exs
+++ b/test/binary/framed/client_test.exs
@@ -54,7 +54,7 @@ defmodule BinaryFramedClientTest do
     assert {:ok,  <<0>>} =  Client.deserialize_message_reply(msg, "my_call", 2757)
   end
 
-  thrift_test "it should be able to deserialize a void message with an empty struct" do
+  thrift_test "it should be able to deserialize a message with an empty struct" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 12, 0, 0, 0, 0>>
 
     assert {:ok, <<12, 0, 0, 0, 0>>} =  Client.deserialize_message_reply(msg, "my_call", 2757)

--- a/test/binary/framed/client_test.exs
+++ b/test/binary/framed/client_test.exs
@@ -12,7 +12,7 @@ defmodule BinaryFramedClientTest do
 
   thrift_test "it should be able to deserialize an invalid message" do
     msg = <<128, 1, 0, 2>>
-    assert {:error, {:cant_decode_message, ^msg}} = Client.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+    assert {:error, {:cant_decode_message, ^msg}} = Client.deserialize_message_reply(msg, "my_call", 2757)
   end
 
   thrift_test "it should be able to read a malformed tapplicationexception" do
@@ -22,7 +22,7 @@ defmodule BinaryFramedClientTest do
     expected_message = "Could not decode TApplicationException, remaining was <<1, 1, 1, 1>>"
     expected_type = :protocol_error
 
-    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "bad", 941, VoidReturns.MyCallResponse)
+    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "bad", 941)
     assert %TAE{message: ^expected_message,
                                          type: ^expected_type} = ex
   end
@@ -30,33 +30,33 @@ defmodule BinaryFramedClientTest do
   thrift_test "it should be able to deserialize a message with a bad sequence id" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
 
-    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1912, VoidReturns.MyCallResponse)
+    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1912)
     assert %TAE{type: :bad_sequence_id} = ex
   end
 
   thrift_test "it should be able to deserialize a message with the wrong method name" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
 
-    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 2757)
     assert %TAE{type: :wrong_method_name} = ex
   end
 
   thrift_test "it should be able to deserialize a message with the wrong method name and sequence id " do
     msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
 
-    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1234, VoidReturns.MyCallResponse)
-    assert %TAE{type: :sequence_id_and_rpc_name_mismatched} = ex
+    assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1234)
+    assert %TAE{type: :bad_sequence_id} = ex
   end
 
   thrift_test "it should be able to deserialize a void message" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
 
-    assert {:ok, nil} =  Client.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+    assert {:ok,  <<0>>} =  Client.deserialize_message_reply(msg, "my_call", 2757)
   end
 
   thrift_test "it should be able to deserialize a void message with an empty struct" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 12, 0, 0, 0, 0>>
 
-    assert {:ok, nil} =  Client.deserialize_message_reply(msg, "my_call", 2757, VoidReturns.MyCallResponse)
+    assert {:ok, <<12, 0, 0, 0, 0>>} =  Client.deserialize_message_reply(msg, "my_call", 2757)
   end
 end


### PR DESCRIPTION
This moves message serialization completely into Binary.Framed.Client, and
response serialization completely out into the generated client. Their
responsibilities are more coherent. It also puts us into position for future
potential improvements, such as moving seq_id management into the connection
process's state, and generating code to match response exceptions in the way we
currently match unions.