### PR TITLE
Ignore tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /src/thrift_lexer.erl
 /src/thrift_parser.erl
 /test/fixtures/app/lib
+/tmp
 erl_crash.dump
 *.ez
 log.*


### PR DESCRIPTION
The tmp directory is used to store temporary .thrift and generated files by
ThriftTestCase. It's typically around during development and contains files but
they should not be checked in.