### PR TITLE
Fix some warnings flagged by Elixir 1.4

### DIFF
--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -331,7 +331,7 @@ defmodule Thrift.Generator.ServiceTest do
     # the server will sleep, so spawn a process to make a request,
     # then kill the server out from under that process. It will
     # trigger the generic error handler in the server
-    me = self
+    me = self()
     spawn fn ->
       Process.send_after(me, :ok, 20)
       Client.friend_ids_of(ctx.client, 14_821)

--- a/test/parser/resolver_test.exs
+++ b/test/parser/resolver_test.exs
@@ -1,6 +1,5 @@
 defmodule ResolverTest do
   use ExUnit.Case
-  @thrift_dir "test/fixtures/app/thrift"
 
   alias Thrift.Parser.FileGroup
   alias Thrift.Parser.Models.{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,6 @@ ExUnit.configure(exclude: [pending: true])
 ExUnit.start()
 
 defmodule ThriftTestHelpers do
-  @root_dir "test/fixtures/thrift/"
 
   defmacro __using__(_) do
     quote do


### PR DESCRIPTION
1. Unused module attributes
2. Variable vs. function name ambiguity