### PR TITLE
Ensure field names are valid elixir function names

### DIFF
--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -6,6 +6,9 @@ defmodule Thrift.Parser.Conversions do
     List.to_atom(l)
   end
 
+  # convert a charlist to a snake_case atom
+  #   e.g., 'FooBar', 'foo_bar', 'fooBar', and 'FOO_BAR'
+  #   should all produce :foo_bar
   def atomic_snake(nil), do: nil
   def atomic_snake(l) when is_list(l) do
     l

--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -6,6 +6,16 @@ defmodule Thrift.Parser.Conversions do
     List.to_atom(l)
   end
 
+  def atomic_snake(nil), do: nil
+  def atomic_snake(l) when is_list(l) do
+    l
+    |> List.to_string
+    |> String.split("_")
+    |> Enum.map(&Macro.underscore/1)
+    |> Enum.join("_")
+    |> String.to_atom
+  end
+
   def cast(_, nil) do
     nil
   end

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -112,7 +112,7 @@ defmodule Thrift.Parser.Models do
     def new(id, required, type, name, default) do
       %Field{id: id,
              type: type,
-             name: atomify(name),
+             name: atomic_snake(name),
              required: required,
              default: cast(type, default)}
     end

--- a/test/generator/models_test.exs
+++ b/test/generator/models_test.exs
@@ -95,6 +95,7 @@ defmodule Thrift.Generator.ModelsTest do
     10: optional struct_includes.RemoteStruct remote_struct;
     11: optional list<LocalStruct> local_struct_list;
     12: optional map<LocalStruct, LocalStruct> local_struct_map;
+    13: optional string DEPRECATED_string;
   }
   """
 
@@ -112,6 +113,7 @@ defmodule Thrift.Generator.ModelsTest do
     assert s.remote_struct == nil
     assert s.local_struct_list == nil
     assert s.local_struct_map == nil
+    assert s.deprecated_string == nil
   end
 
   @thrift_file name: "typedefs.thrift", contents: """

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -444,7 +444,7 @@ defmodule ParserTest do
       name: :EmptyDefault,
       fields: [
         %Field{default: nil, id: 1, name: :id, required: :default, type: :i64},
-        %Field{default: %{}, id: 2, name: :myMap,
+        %Field{default: %{}, id: 2, name: :my_map,
                required: :default, type: {:map, {:string, :string}}}
       ]}
   end


### PR DESCRIPTION
This deserves automatic approval just because I got to define a function called `atomic_snake` :laughing:

Caveat: See https://github.com/elixir-lang/elixir/issues/5627 - I sort of expected `Macro.underscore/1` to normalize things but it has unexpected behavior (to me, at least).  If this does turn out to be a bug, we could simplify the function a bit.  The workaround that I used _should_ still work either way.

Closes #161