### PR TITLE
Timeout / Retry refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,11 @@ Name             | Type | Description
 ```elixir
 alias Thrift.Test.UserService.Clients.Binary.Framed, as: Client
 {:ok, client} = Client.start_link("localhost", 2345,
-                tcp_opts: [backoff_calculator: fn(retry_count) -> retry_count * 1000 end], gen_server_opts: [timeout: 10_000])
+                tcp_opts: [retry: true], gen_server_opts: [timeout: 10_000])
 
 ```
-In the above example, the client will use a (very) conservative backoff calculator
-that waits an additional second each time the client retries. In other words, the first
-retry will wait 1 second, the second will wait 2 seconds, and the third will wait 3.
-These options set the GenServer timeout to be ten seconds, which means the remote
+In the above example, the client will retry once if the remote server severs the connection.
+These options also set the GenServer timeout to be ten seconds, which means the remote
 side can take its time to reply.
 
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ Name             | Type | Description
 -----------------|------|---------------
 `:timeout`       | positive integer | The default timeout for reading from, writing to, and connecting to sockets.
 `send_timeout`   | positive integer | The amount of time in milliseconds to wait before sending data fails.
-`backoff_calculator` | (int) -> int | A single argument function that takes the number of retries and returns the amount of time to wait in milliseconds before reconnecting. The default implementation waits 100, 100, 200, 300, 500, 800 and then 1000 ms. All retries after that will wait 1000ms.
-
+`retry` | boolean | Whether or not to retry if the server closes the connection (default false). If the client detects that the server has closed the connection, the last message will be retried. This is helpful when using the client in IEx, or in a situation where the client won't be used for a while, but can result in duplicate messages being sent to the server. Due to the subtleties of `gen_tcp`, oneway messages are not retried.
 
 ##### GenServer Opts
 Name             | Type | Description

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -223,7 +223,7 @@ defmodule Thrift.Binary.Framed.Client do
       {:error, :timeout} = timeout ->
         {:reply, timeout, s}
 
-      {:error, :closed} = err->
+      {:error, :closed} = err ->
         {:disconnect, {:retry, err}, %{s |last_message: {call_args, caller}}}
 
       {:error, _} = error ->

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -28,7 +28,6 @@ defmodule Thrift.Binary.Framed.Client do
   @type tcp_opts :: [
     timeout: pos_integer,
     send_timeout: integer,
-    max_retries: non_neg_integer | :infinity
   ]
 
   @type genserver_call_options :: [
@@ -95,7 +94,7 @@ defmodule Thrift.Binary.Framed.Client do
 
      - `send_timeout`: An integer that governs how long our connection waits when sending data.
 
-     - `retry`: An boolean that tells the client whether or not it should retry on failures.
+     - `retry`: A boolean that tells the client whether or not it should retry on failures.
 
 
     `gen_server_opts`: A keyword list of options that control the gen_server behaviour.

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -75,7 +75,6 @@ defmodule Thrift.Binary.Framed.Client do
                port: port,
                tcp_opts: tcp_opts,
                timeout: timeout,
-               sock: nil,
                retry: should_retry}
 
     {:connect, :init, s}
@@ -169,7 +168,12 @@ defmodule Thrift.Binary.Framed.Client do
         Logger.error("Connection error: #{reason}")
 
       {:retry, _} ->
-        Logger.info("Retrying call")
+        case s.last_message do
+          {type, rpc_name, _, _} ->
+            Logger.info("Retrying #{type} #{rpc_name}")
+          _ ->
+            Logger.info("Retrying failed call")
+        end
     end
     {:connect, info, %{s | sock: nil}}
   end

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -22,7 +22,7 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
 
     {recv_timeout, tcp_opts} = Keyword.pop(tcp_opts, :recv_timeout, @default_timeout)
 
-    transport_options = Keyword.merge(tcp_opts, [packet: 4])
+    transport_options = Keyword.put(tcp_opts, :packet, 4)
     transport.setopts(socket, transport_options)
 
     do_thrift_call({transport, socket, server_module, handler_module, recv_timeout})

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -2,11 +2,6 @@ defmodule Thrift.Binary.Framed.Server
   do
   @moduledoc false
 
-  @type tcp_options :: [
-    recv_timeout: timeout,
-    send_timeout: timeout
-  ]
-
   @type server_opts :: [
     worker_count: pos_integer,
     name: atom,

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -4,7 +4,6 @@ defmodule Thrift.Binary.Framed.Server
 
   @type tcp_options :: [
     recv_timeout: timeout,
-    timeout: timeout,
     send_timeout: timeout
   ]
 

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -2,11 +2,18 @@ defmodule Thrift.Binary.Framed.Server
   do
   @moduledoc false
 
+  @type tcp_options :: [
+    recv_timeout: timeout,
+    timeout: timeout,
+    send_timeout: timeout
+  ]
+
   @type server_opts :: [
     worker_count: pos_integer,
     name: atom,
     max_restarts: non_neg_integer,
-    max_seconds: non_neg_integer
+    max_seconds: non_neg_integer,
+    tcp_opts: :ranch_tcp.opts
   ]
 
   @spec start_link(module, (1..65535), module, server_opts) :: GenServer.on_start
@@ -15,13 +22,14 @@ defmodule Thrift.Binary.Framed.Server
     max_restarts = Keyword.get(opts, :max_restarts, 10)
     max_seconds = Keyword.get(opts, :max_seconds, 5)
     worker_count = Keyword.get(opts, :worker_count, 1)
+    tcp_opts = Keyword.get(opts, :tcp_opts, [])
 
     listener = :ranch.child_spec(name,
                                  worker_count,
                                  :ranch_tcp,
                                  [port: port],
                                  Thrift.Binary.Framed.ProtocolHandler,
-                                 {server_module, handler_module})
+                                 {server_module, handler_module, tcp_opts})
     Supervisor.start_link([listener], strategy: :one_for_one,
                           max_restarts: max_restarts, max_seconds: max_seconds)
   end

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -345,9 +345,9 @@ defmodule Thrift.Generator.ServiceTest do
 
   thrift_test "clients retry when making a oneway call on a closed server when retry is true", ctx do
     stop_server(ctx.server)
-
+    {:ok, server} = start_server(ctx.port, 20)
     {:ok, client} = Client.start_link("127.0.0.1", ctx.port, [tcp_opts: [retry: true]])
-    {:ok, server} = start_server(ctx.port)
+    :timer.sleep(50)
 
     assert {:ok, nil} = Client.do_some_work(client, "Do the work!")
 

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -333,7 +333,7 @@ defmodule Thrift.Generator.ServiceTest do
     stop_server(ctx.server)
     {:ok, server} = start_server(ctx.port, 20)
 
-    :timer.sleep(20) # wait for the server to come up.
+    :timer.sleep(1000) # wait for the server to come up.
 
     {:ok, client} = Client.start_link("127.0.0.1", ctx.port, [tcp_opts: [retry: true]])
     :timer.sleep(50)

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -332,6 +332,9 @@ defmodule Thrift.Generator.ServiceTest do
   thrift_test "clients retry when making an RPC on a closed server when retry is true", ctx do
     stop_server(ctx.server)
     {:ok, server} = start_server(ctx.port, 20)
+
+    :timer.sleep(20) # wait for the server to come up.
+
     {:ok, client} = Client.start_link("127.0.0.1", ctx.port, [tcp_opts: [retry: true]])
     :timer.sleep(50)
 

--- a/test/generator/service_test.exs
+++ b/test/generator/service_test.exs
@@ -327,13 +327,12 @@ defmodule Thrift.Generator.ServiceTest do
 
   thrift_test "clients retry when making an RPC on a closed server when retry is true", ctx do
     stop_server(ctx.server)
-
+    {:ok, server} = start_server(ctx.port, 20)
     {:ok, client} = Client.start_link("127.0.0.1", ctx.port, [tcp_opts: [retry: true]])
-    {:ok, server} = start_server(ctx.port)
+    :timer.sleep(50)
 
     ServerSpy.set_reply([9, 8, 7, 6])
-
-    assert {:ok, _} = Client.friend_ids_of(client, 1234)
+    assert {:ok, [9, 8, 7, 6]} = Client.friend_ids_of(client, 1234)
   end
 
   thrift_test "clients retry when making a oneway call on a closed server when retry is true", ctx do


### PR DESCRIPTION
Servers now support read timeouts

Additionally, I changed how we handle retries due to some idiosyncracies
with how erlang responds to server failures.

When the server closes the connection, the client's `:gen_tcp.send`
operation will always succeed, failing instead on the corresponding
`:gen_tcp.recv` command. This is problematic, because we can't know for
sure that a message has been sent, and if we retry, we might resend a
message accidentally.

Furthermore, we can _never_ really know if a oneway message has been
sent or not.

Admittedly, the window for this is pretty narrow, the server would have
to sever the connection between the send and recv calls. The next case
is more troublesome.

Since we have backoff behavior, imagine if the user has set a retry
count of `:infinity` and made a call to a dead server. Now the client is
backing off and the `GenServer` call will timeout after 5 seconds. The
client is now stuck in a loop, reconnecting forever.

In light of these issues, I've removed repeated reconnects from the
client and have implemented a one-shot reconnect. We can still send a
message twice, but the window is sufficiently small to make me not worry
so much. This also has the effect of improving UX in the light of a
server that disconnects clients after a short timeout. If you send a
message on a disconnected client, it remembers it, reconnects and sends
it.

That seems reasonable.