### PR TITLE
Wrap long lines in generated output

### DIFF
--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -64,8 +64,8 @@ defmodule Thrift.Generator.Binary.Framed.Client do
 
     quote do
       unquote(def_type)(unquote(underscored_options_name)(client, unquote_splicing(vars), opts)) do
-        serialized_args = %unquote(args_module){unquote_splicing(assignments)}
-        |> unquote(args_module).BinaryProtocol.serialize
+        args = %unquote(args_module){unquote_splicing(assignments)}
+        serialized_args = unquote(args_module).BinaryProtocol.serialize(args)
 
         unquote(build_response_handler(function, rpc_name, response_module))
       end

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -99,9 +99,8 @@ defmodule Thrift.Generator.Binary.Framed.Server do
 
         quote do
           unquote(error_var) in unquote(dest_module) ->
-            serialized_exception = %unquote(response_module){unquote(field_setter)}
-            |> unquote(response_module).BinaryProtocol.serialize()
-            {:reply, serialized_exception}
+            response = %unquote(response_module){unquote(field_setter)}
+            {:reply, unquote(response_module).BinaryProtocol.serialize(response)}
         end
     end)
 


### PR DESCRIPTION
Generated module names can be quite long, so this pattern produces very long
lines because Macro.to_string does not wrap pipe operators to the next line.

  serialized_var = %Big.Generated.Module{} |> Big.Generated.Module.serialize()

This change just replaces it with a slightly more readable:

  var = %Big.Generated.Module{}
  Big.GeneratedModule.serialize(var)