### PR TITLE
Consolidate binary protocol field type constants

### DIFF
--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -10,7 +10,7 @@ defmodule Thrift do
 
   @typedoc "Thrift data types"
   @type data_type ::
-    :bool | :byte | :i16 | :i32 | :i64 | :double | :string | :struct | :union |
+    :bool | :byte | :i16 | :i32 | :i64 | :double | :string |
     {:map, data_type, data_type} | {:set, data_type} | {:list, data_type}
 
   @type i8   :: (-128..127)

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -49,18 +49,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     Union,
   }
 
-  @bool 2
-  @byte 3
-  @double 4
-  @i16 6
-  @i32 8
-  @i64 10
-  @string 11
-  @struct 12
-  @union 12
-  @map 13
-  @set 14
-  @list 15
+  require Thrift.Protocol.Binary.Type, as: Type
 
   @doc """
   Generate a deserializer for a Thrift struct, union or exception.
@@ -96,10 +85,10 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
   defp field_deserializer(:bool, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@bool), unquote(field.id)::16-signed, 1, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.bool), unquote(field.id)::16-signed, 1, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => true})
       end
-      defp unquote(name)(<<unquote(@bool), unquote(field.id)::16-signed, 0, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.bool), unquote(field.id)::16-signed, 0, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => false})
       end
     end
@@ -109,28 +98,28 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp field_deserializer(:i8, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@byte), unquote(field.id)::16-signed, value, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.byte), unquote(field.id)::16-signed, value, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
   end
   defp field_deserializer(:double, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@double), unquote(field.id)::16-signed, value::signed-float, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.double), unquote(field.id)::16-signed, value::signed-float, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
   end
   defp field_deserializer(:i16, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@i16), unquote(field.id)::16-signed, value::size(16), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i16), unquote(field.id)::16-signed, value::size(16), rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
   end
   defp field_deserializer(:i32, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@i32), unquote(field.id)::16-signed, value::size(32), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i32), unquote(field.id)::16-signed, value::size(32), rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
@@ -140,7 +129,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp field_deserializer(:i64, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@i64), unquote(field.id)::16-signed, value::size(64), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i64), unquote(field.id)::16-signed, value::size(64), rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
@@ -150,7 +139,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp field_deserializer(:string, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(@string),
+      defp unquote(name)(<<unquote(Type.string),
                          unquote(field.id)::16-signed,
                          string_size::32-signed,
                          value::binary-size(string_size),
@@ -163,7 +152,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   defp field_deserializer(%Struct{} = struct, field, name, file_group) do
     dest_module = FileGroup.dest_module(file_group, struct)
     quote do
-      defp unquote(name)(<<unquote(@struct), unquote(field.id)::16-signed, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.struct), unquote(field.id)::16-signed, rest::binary>>, acc) do
         case unquote(dest_module).BinaryProtocol.deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
@@ -176,7 +165,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   defp field_deserializer(%Union{} = union, field, name, file_group) do
     dest_module = FileGroup.dest_module(file_group, union)
     quote do
-      defp unquote(name)(<<unquote(@union), unquote(field.id)::16-signed, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.struct), unquote(field.id)::16-signed, rest::binary>>, acc) do
         case unquote(dest_module).BinaryProtocol.deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
@@ -189,7 +178,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   defp field_deserializer(%Exception{} = struct, field, name, file_group) do
     dest_module = FileGroup.dest_module(file_group, struct)
     quote do
-      defp unquote(name)(<<unquote(@struct), unquote(field.id)::16-signed, rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.struct), unquote(field.id)::16-signed, rest::binary>>, acc) do
         case unquote(dest_module).BinaryProtocol.deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
@@ -203,7 +192,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     key_name = :"#{name}__#{field.name}__key"
     value_name = :"#{name}__#{field.name}__value"
     quote do
-      defp unquote(name)(<<unquote(@map),
+      defp unquote(name)(<<unquote(Type.map),
                            unquote(field.id)::16-signed,
                            unquote(type_id(key_type, file_group)),
                            unquote(type_id(value_type, file_group)),
@@ -223,7 +212,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   defp field_deserializer({:set, element_type}, field, name, file_group) do
     sub_name = :"#{name}__#{field.name}"
     quote do
-      defp unquote(name)(<<unquote(@set),
+      defp unquote(name)(<<unquote(Type.set),
                            unquote(field.id)::16-signed,
                            unquote(type_id(element_type, file_group)),
                            remaining::size(32),
@@ -240,7 +229,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   defp field_deserializer({:list, element_type}, field, name, file_group) do
     sub_name = :"#{name}__#{field.name}"
     quote do
-      defp unquote(name)(<<unquote(@list),
+      defp unquote(name)(<<unquote(Type.list),
                            unquote(field.id)::16-signed,
                            unquote(type_id(element_type, file_group)),
                            remaining::size(32),
@@ -782,9 +771,9 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     quote do
       case unquote(Macro.var(name, nil)) do
         false ->
-          <<unquote(@bool), unquote(id) :: size(16), 0>>
+          <<unquote(Type.bool), unquote(id) :: size(16), 0>>
         true ->
-          <<unquote(@bool), unquote(id) :: size(16), 1>>
+          <<unquote(Type.bool), unquote(id) :: size(16), 1>>
         _ ->
           raise Thrift.InvalidValueException,
                 unquote("Required boolean field #{inspect name} on #{inspect struct_name} must be true or false")
@@ -797,9 +786,9 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         nil ->
           <<>>
         false ->
-          <<unquote(@bool), unquote(id) :: size(16), 0>>
+          <<unquote(Type.bool), unquote(id) :: size(16), 0>>
         true ->
-          <<unquote(@bool), unquote(id) :: size(16), 1>>
+          <<unquote(Type.bool), unquote(id) :: size(16), 1>>
         _ ->
           raise Thrift.InvalidValueException,
                 unquote("Optional boolean field #{inspect name} on #{inspect struct_name} must be true, false, or nil")
@@ -912,23 +901,22 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     |> value_serializer(var, file_group)
   end
 
-
-  defp type_id(:bool, _file_group), do: 2
-  defp type_id(:byte, _file_group), do: 3
-  defp type_id(:i8, _file_group), do: 3
-  defp type_id(:double, _file_group), do: 4
-  defp type_id(:i16, _file_group), do: 6
-  defp type_id(:i32, _file_group), do: 8
-  defp type_id(%TEnum{}, _file_group), do: 8
-  defp type_id(:i64, _file_group), do: 10
-  defp type_id(:string, _file_group), do: 11
-  defp type_id(:binary, _file_group), do: 11
-  defp type_id(%Struct{}, _file_group), do: 12
-  defp type_id(%Exception{}, _file_group), do: 12
-  defp type_id(%Union{}, _file_group), do: 12
-  defp type_id({:map, _}, _file_group), do: 13
-  defp type_id({:set, _}, _file_group), do: 14
-  defp type_id({:list, _}, _file_group), do: 15
+  defp type_id(:bool, _file_group),         do: Type.bool
+  defp type_id(:byte, _file_group),         do: Type.byte
+  defp type_id(:i8, _file_group),           do: Type.i8
+  defp type_id(:i16, _file_group),          do: Type.i16
+  defp type_id(:i32, _file_group),          do: Type.i32
+  defp type_id(:i64, _file_group),          do: Type.i64
+  defp type_id(:double, _file_group),       do: Type.double
+  defp type_id(:string, _file_group),       do: Type.string
+  defp type_id(:binary, _file_group),       do: Type.string
+  defp type_id({:map, _}, _file_group),     do: Type.map
+  defp type_id({:set, _}, _file_group),     do: Type.set
+  defp type_id({:list, _}, _file_group),    do: Type.list
+  defp type_id(%TEnum{}, _file_group),      do: Type.i32
+  defp type_id(%Struct{}, _file_group),     do: Type.struct
+  defp type_id(%Exception{}, _file_group),  do: Type.struct
+  defp type_id(%Union{}, _file_group),      do: Type.struct
   defp type_id(%TypeRef{referenced_type: type}, file_group) do
     FileGroup.resolve(file_group, type)
     |> type_id(file_group)

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -901,24 +901,13 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     |> value_serializer(var, file_group)
   end
 
-  defp type_id(:bool, _file_group),         do: Type.bool
-  defp type_id(:byte, _file_group),         do: Type.byte
-  defp type_id(:i8, _file_group),           do: Type.i8
-  defp type_id(:i16, _file_group),          do: Type.i16
-  defp type_id(:i32, _file_group),          do: Type.i32
-  defp type_id(:i64, _file_group),          do: Type.i64
-  defp type_id(:double, _file_group),       do: Type.double
-  defp type_id(:string, _file_group),       do: Type.string
-  defp type_id(:binary, _file_group),       do: Type.string
-  defp type_id({:map, _}, _file_group),     do: Type.map
-  defp type_id({:set, _}, _file_group),     do: Type.set
-  defp type_id({:list, _}, _file_group),    do: Type.list
-  defp type_id(%TEnum{}, _file_group),      do: Type.i32
-  defp type_id(%Struct{}, _file_group),     do: Type.struct
-  defp type_id(%Exception{}, _file_group),  do: Type.struct
-  defp type_id(%Union{}, _file_group),      do: Type.struct
   defp type_id(%TypeRef{referenced_type: type}, file_group) do
     FileGroup.resolve(file_group, type)
     |> type_id(file_group)
   end
+  defp type_id(%TEnum{}, _),      do: Type.i32
+  defp type_id(%Struct{}, _),     do: Type.struct
+  defp type_id(%Exception{}, _),  do: Type.struct
+  defp type_id(%Union{}, _),      do: Type.struct
+  defp type_id(type, _),          do: Type.of(type)
 end

--- a/lib/thrift/protocol/binary.ex
+++ b/lib/thrift/protocol/binary.ex
@@ -10,35 +10,24 @@ defmodule Thrift.Protocol.Binary do
 
   alias Thrift.TApplicationException
 
-  @typedoc "Binary protocol field type identifier"
-  @type type_id :: 2 | 3 | 4 | 6 | 8 | 10 | 11 | 12 | 13 | 14 | 15
+  require Thrift.Protocol.Binary.Type, as: Type
+
   @type deserializable :: :message_begin | :application_exception
 
-  @stop   0
-  @bool   2
-  @byte   3   # also: i8
-  @double 4
-  @i16    6
-  @i32    8
-  @i64    10
-  @string 11
-  @struct 12
-  @map    13
-  @set    14
-  @list   15
+  @stop 0
 
-  @spec type_id(Thrift.data_type) :: type_id
-  defp type_id(:bool),      do: @bool
-  defp type_id(:byte),      do: @byte
-  defp type_id(:i16),       do: @i16
-  defp type_id(:i32),       do: @i32
-  defp type_id(:i64),       do: @i64
-  defp type_id(:double),    do: @double
-  defp type_id(:string),    do: @string
-  defp type_id(:struct),    do: @struct
-  defp type_id({:map, _}),  do: @map
-  defp type_id({:set, _}),  do: @set
-  defp type_id({:list, _}), do: @list
+  @spec type_id(Thrift.data_type) :: Type.t
+  defp type_id(:bool),      do: Type.bool
+  defp type_id(:byte),      do: Type.byte
+  defp type_id(:i16),       do: Type.i16
+  defp type_id(:i32),       do: Type.i32
+  defp type_id(:i64),       do: Type.i64
+  defp type_id(:double),    do: Type.double
+  defp type_id(:string),    do: Type.string
+  defp type_id(:struct),    do: Type.struct
+  defp type_id({:map, _}),  do: Type.map
+  defp type_id({:set, _}),  do: Type.set
+  defp type_id({:list, _}), do: Type.list
 
   @typedoc "Binary protocol message type identifier"
   @type message_type_id :: (1..4)
@@ -105,8 +94,8 @@ defmodule Thrift.Protocol.Binary do
     serialize(:application_exception, %TApplicationException{exc | type: TApplicationException.exception_type_to_int(t)})
   end
   def serialize(:application_exception, %TApplicationException{message: message, type: type}) do
-    <<@string::size(8), 1::16-signed, byte_size(message)::size(32), message::binary,
-      @i32::size(8), 2::16-signed, type::32-signed, @stop>>
+    <<Type.string::size(8), 1::16-signed, byte_size(message)::size(32), message::binary,
+      Type.i32::size(8), 2::16-signed, type::32-signed, @stop>>
   end
 
 
@@ -138,7 +127,7 @@ defmodule Thrift.Protocol.Binary do
   end
 
   defp do_read_application_exception(
-        <<@string::size(8),
+        <<Type.string::size(8),
         1::16-unsigned,
         message_size::32-signed,
         message::binary-size(message_size),
@@ -147,7 +136,7 @@ defmodule Thrift.Protocol.Binary do
     do_read_application_exception(rest, Map.put(accum, :message, message))
   end
   defp do_read_application_exception(
-        <<@i32::size(8),
+        <<Type.i32::size(8),
         2::16-unsigned,
         type::32-signed,
         rest::binary>>, accum) do
@@ -171,26 +160,26 @@ defmodule Thrift.Protocol.Binary do
   This is useful for jumping over unrecognized fields in the serialized byte
   stream.
   """
-  @spec skip_field(binary, type_id) :: binary | :error
-  def skip_field(<<_, rest::binary>>, unquote(@bool)), do: rest
-  def skip_field(<<_, rest::binary>>, unquote(@byte)), do: rest
-  def skip_field(<<_::signed-float, rest::binary>>, unquote(@double)), do: rest
-  def skip_field(<<_::size(16), rest::binary>>, unquote(@i16)), do: rest
-  def skip_field(<<_::size(32), rest::binary>>, unquote(@i32)), do: rest
-  def skip_field(<<_::size(64), rest::binary>>, unquote(@i64)), do: rest
-  def skip_field(<<length::32-signed, _::binary-size(length), rest::binary>>, unquote(@string)) do
+  @spec skip_field(binary, Type.t) :: binary | :error
+  def skip_field(<<_, rest::binary>>, unquote(Type.bool)), do: rest
+  def skip_field(<<_, rest::binary>>, unquote(Type.byte)), do: rest
+  def skip_field(<<_::signed-float, rest::binary>>, unquote(Type.double)), do: rest
+  def skip_field(<<_::size(16), rest::binary>>, unquote(Type.i16)), do: rest
+  def skip_field(<<_::size(32), rest::binary>>, unquote(Type.i32)), do: rest
+  def skip_field(<<_::size(64), rest::binary>>, unquote(Type.i64)), do: rest
+  def skip_field(<<length::32-signed, _::binary-size(length), rest::binary>>, unquote(Type.string)) do
     rest
   end
-  def skip_field(<<rest::binary>>, unquote(@struct)) do
+  def skip_field(<<rest::binary>>, unquote(Type.struct)) do
     rest |> skip_struct
   end
-  def skip_field(<<key_type, val_type, length::size(32), rest::binary>>, unquote(@map)) do
+  def skip_field(<<key_type, val_type, length::size(32), rest::binary>>, unquote(Type.map)) do
     rest |> skip_map_entry(key_type, val_type, length)
   end
-  def skip_field(<<elem_type, length::size(32), rest::binary>>, unquote(@set)) do
+  def skip_field(<<elem_type, length::size(32), rest::binary>>, unquote(Type.set)) do
     rest |> skip_list_element(elem_type, length)
   end
-  def skip_field(<<elem_type, length::size(32), rest::binary>>, unquote(@list)) do
+  def skip_field(<<elem_type, length::size(32), rest::binary>>, unquote(Type.list)) do
     rest |> skip_list_element(elem_type, length)
   end
   def skip_field(_, _), do: :error

--- a/lib/thrift/protocol/binary/type.ex
+++ b/lib/thrift/protocol/binary/type.ex
@@ -1,0 +1,20 @@
+defmodule Thrift.Protocol.Binary.Type do
+  @moduledoc false
+
+  @typedoc "Binary protocol field type identifier"
+  @type t :: 2 | 3 | 4 | 6 | 8 | 10 | 11 | 12 | 13 | 14 | 15
+
+  defmacro bool,    do: 2
+  defmacro byte,    do: 3
+  defmacro double,  do: 4
+  defmacro i8,      do: 3
+  defmacro i16,     do: 6
+  defmacro i32,     do: 8
+  defmacro i64,     do: 10
+  defmacro string,  do: 11
+  defmacro struct,  do: 12
+  defmacro map,     do: 13
+  defmacro set,     do: 14
+  defmacro list,    do: 15
+end
+

--- a/lib/thrift/protocol/binary/type.ex
+++ b/lib/thrift/protocol/binary/type.ex
@@ -16,5 +16,18 @@ defmodule Thrift.Protocol.Binary.Type do
   defmacro map,     do: 13
   defmacro set,     do: 14
   defmacro list,    do: 15
+
+  @spec of(Thrift.data_type) :: t
+  def of(:bool),      do: bool()
+  def of(:byte),      do: byte()
+  def of(:i16),       do: i16()
+  def of(:i32),       do: i32()
+  def of(:i64),       do: i64()
+  def of(:double),    do: double()
+  def of(:string),    do: string()
+  def of(:struct),    do: struct()
+  def of({:map, _}),  do: map()
+  def of({:set, _}),  do: set()
+  def of({:list, _}), do: list()
 end
 

--- a/lib/thrift/protocol/binary/type.ex
+++ b/lib/thrift/protocol/binary/type.ex
@@ -20,10 +20,12 @@ defmodule Thrift.Protocol.Binary.Type do
   @spec of(Thrift.data_type) :: t
   def of(:bool),      do: bool()
   def of(:byte),      do: byte()
+  def of(:i8),        do: i8()
   def of(:i16),       do: i16()
   def of(:i32),       do: i32()
   def of(:i64),       do: i64()
   def of(:double),    do: double()
+  def of(:binary),    do: string()
   def of(:string),    do: string()
   def of(:struct),    do: struct()
   def of({:map, _}),  do: map()

--- a/lib/thrift/protocol/binary/type.ex
+++ b/lib/thrift/protocol/binary/type.ex
@@ -27,7 +27,6 @@ defmodule Thrift.Protocol.Binary.Type do
   def of(:double),    do: double()
   def of(:binary),    do: string()
   def of(:string),    do: string()
-  def of(:struct),    do: struct()
   def of({:map, _}),  do: map()
   def of({:set, _}),  do: set()
   def of({:list, _}), do: list()


### PR DESCRIPTION
We previously defined nearly identical sets of constants representing
the binary protocol's field types as attributes in each module that
required them. This duplication isn't great for long-term maintenance.

This approach defines a single set of type constants as macros in a
new `Thrift.Protocol.Binary.Type` module. Using macros lets us preserve
all of the compile-time benefits we were getting from the previous
approach while still supporting code sharing.