### PR TITLE
Group compiler options under a :thrift key

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Next, configure the compiler using a new Keyword list under the top-level
 which defines the list of Thrift files that should be compiled.
 
 By default, the generated source files will be written to the `lib` directory,
-but you can change that using the `output` option.
+but you can change that using the `output_path` option.
 
 In this example, we gather all of the `.thrift` files under the `thrift`
 directory and write our output to the `lib/thrift/` directory:
@@ -81,7 +81,7 @@ directory and write our output to the `lib/thrift/` directory:
 ```elixir
 thrift: [
   files: Mix.Utils.extract_files(["thrift"], [:thrift]),
-  output: "lib/thrift/"
+  output_path: "lib/thrift/"
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,22 @@ It's important to add `:thrift` *before* the `:elixir` entry. The Thrift
 compiler will generate Elixir source files, which are in turn compiled by the
 `:elixir` compiler.
 
-Next, define the list of `:thrift_files` that should be compiled. In this
-example, we gather all of the `.thrift` files under the `thrift` directory:
-
-```elixir
-thrift_files: Mix.Utils.extract_files(["thrift"], [:thrift])
-```
+Next, configure the compiler using a new Keyword list under the top-level
+`:thrift` configuration key. The only necessary compiler option is `:files`,
+which defines the list of Thrift files that should be compiled.
 
 By default, the generated source files will be written to the `lib` directory,
-but you can change that using the `thrift_output` option.
+but you can change that using the `output` option.
+
+In this example, we gather all of the `.thrift` files under the `thrift`
+directory and write our output to the `lib/thrift/` directory:
+
+```elixir
+thrift: [
+  files: Mix.Utils.extract_files(["thrift"], [:thrift]),
+  output: "lib/thrift/"
+]
+```
 
 ## Working with Thrift
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ directory and write our output to the `lib/thrift/` directory:
 
 ```elixir
 thrift: [
-  files: Mix.Utils.extract_files(["thrift"], [:thrift]),
+  files: Path.wildcard("thrift/**/*.thrift"),
   output_path: "lib/thrift/"
 ]
 ```

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -18,9 +18,9 @@ defmodule Mix.Tasks.Compile.Thrift do
 
   ## Configuration
 
-    * `:thrift_files` - list of `.thrift` schema files to compile
-    * `:thrift_output` - output directory into which the generated Elixir
-      source file will be generated. Defaults to `"lib"`.
+    * `:files` - list of `.thrift` schema files to compile
+    * `:output_path` - output directory into which the generated Elixir
+      source files will be generated. Defaults to `"lib"`.
   """
 
   @spec run(OptionParser.argv) :: :ok
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Compile.Thrift do
 
     config      = Keyword.get(Mix.Project.config, :thrift, [])
     files       = Keyword.get(config, :files, [])
-    output_dir  = Keyword.get(config, :output, "lib")
+    output_path = Keyword.get(config, :output_path, "lib")
 
     file_groups =
       files
@@ -38,13 +38,13 @@ defmodule Mix.Tasks.Compile.Thrift do
       |> Enum.reject(&is_nil/1)
 
     stale_groups = Enum.filter(file_groups, fn file_group ->
-      opts[:force] || stale?(file_group, output_dir)
+      opts[:force] || stale?(file_group, output_path)
     end)
 
     unless Enum.empty?(stale_groups) do
-      File.mkdir_p!(output_dir)
+      File.mkdir_p!(output_path)
       Mix.Utils.compiling_n(length(stale_groups), :thrift)
-      Enum.each(stale_groups, &generate(&1, output_dir, opts))
+      Enum.each(stale_groups, &generate(&1, output_path, opts))
     end
   end
 
@@ -58,16 +58,16 @@ defmodule Mix.Tasks.Compile.Thrift do
     end
   end
 
-  defp stale?(%FileGroup{initial_file: thrift_file} = group, output_dir) do
+  defp stale?(%FileGroup{initial_file: thrift_file} = group, output_path) do
     targets =
       group
       |> Thrift.Generator.targets
-      |> Enum.map(&Path.join(output_dir, &1))
+      |> Enum.map(&Path.join(output_path, &1))
     Mix.Utils.stale?([thrift_file], targets)
   end
 
-  defp generate(%FileGroup{} = group, output_dir, opts) do
-    Thrift.Generator.generate!(group, output_dir)
+  defp generate(%FileGroup{} = group, output_path, opts) do
+    Thrift.Generator.generate!(group, output_path)
     if opts[:verbose] do
       Mix.shell.info "Compiled #{group.initial_file}"
     end

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -28,12 +28,12 @@ defmodule Mix.Tasks.Compile.Thrift do
     {opts, _} = OptionParser.parse!(args,
       switches: [force: :boolean, verbose: :boolean])
 
-    config       = Mix.Project.config
-    thrift_files = Keyword.get(config, :thrift_files, [])
-    output_dir   = Keyword.get(config, :thrift_output, "lib")
+    config      = Keyword.get(Mix.Project.config, :thrift, [])
+    files       = Keyword.get(config, :files, [])
+    output_dir  = Keyword.get(config, :output, "lib")
 
     file_groups =
-      thrift_files
+      files
       |> Enum.map(&parse/1)
       |> Enum.reject(&is_nil/1)
 

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -29,8 +29,8 @@ defmodule Mix.Tasks.Thrift.Generate do
       aliases: [o: :out, v: :verbose],
       switches: [out: :string, verbose: :boolean])
 
-    config     = Mix.Project.config
-    output_dir = opts[:out] || Keyword.get(config, :thrift_output, "lib")
+    config     = Keyword.get(Mix.Project.config, :thrift, [])
+    output_dir = opts[:out] || Keyword.get(config, :output, "lib")
 
     unless Enum.empty?(files) do
       File.mkdir_p!(output_dir)

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -13,14 +13,14 @@ defmodule Mix.Tasks.Thrift.Generate do
 
   ## Command line options
 
-    * `-o` `--out` - set the output directory, overriding the `:thrift_output`
+    * `-o` `--out` - set the output directory, overriding the `:output_path`
       configuration value
     * `-v` `--verbose` - enable verbose task logging
 
   ## Configuration
 
-    * `:thrift_output` - output directory into which the generated Elixir
-      source file will be generated. Defaults to `"lib"`.
+    * `:output_path` - output directory into which the generated Elixir
+      source files will be generated. Defaults to `"lib"`.
   """
 
   @spec run(OptionParser.argv) :: :ok
@@ -29,12 +29,12 @@ defmodule Mix.Tasks.Thrift.Generate do
       aliases: [o: :out, v: :verbose],
       switches: [out: :string, verbose: :boolean])
 
-    config     = Keyword.get(Mix.Project.config, :thrift, [])
-    output_dir = opts[:out] || Keyword.get(config, :output, "lib")
+    config      = Keyword.get(Mix.Project.config, :thrift, [])
+    output_path = opts[:out] || Keyword.get(config, :output_path, "lib")
 
     unless Enum.empty?(files) do
-      File.mkdir_p!(output_dir)
-      Enum.each(files, &generate!(&1, output_dir, opts))
+      File.mkdir_p!(output_path)
+      Enum.each(files, &generate!(&1, output_path, opts))
     end
   end
 
@@ -47,13 +47,13 @@ defmodule Mix.Tasks.Thrift.Generate do
     end
   end
 
-  defp generate!(thrift_file, output_dir, opts) do
+  defp generate!(thrift_file, output_path, opts) do
     Mix.shell.info "Parsing #{thrift_file}"
 
     generated_files =
       thrift_file
       |> parse!
-      |> Thrift.Generator.generate!(output_dir)
+      |> Thrift.Generator.generate!(output_path)
 
     if opts[:verbose] do
       generated_files

--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -4,6 +4,6 @@ defmodule App.Mixfile do
   def project do
     [app: :app,
      version: "1.0.0",
-     thrift_files: Mix.Utils.extract_files(["thrift"], [:thrift])]
+     thrift: [files: Mix.Utils.extract_files(["thrift"], [:thrift])]]
   end
 end

--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -4,6 +4,6 @@ defmodule App.Mixfile do
   def project do
     [app: :app,
      version: "1.0.0",
-     thrift: [files: Mix.Utils.extract_files(["thrift"], [:thrift])]]
+     thrift: [files: Path.wildcard("thrift/**/*.thrift")]]
   end
 end

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     :ok
   end
 
-  test "compiling default :thrift_files" do
+  test "compiling default :files" do
     in_fixture fn ->
       with_project_config [], fn ->
         assert run([]) =~ """
@@ -53,9 +53,9 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
-  test "specifying an empty :thrift_files list" do
+  test "specifying an empty :files list" do
     in_fixture fn ->
-      with_project_config [thrift_files: []], fn ->
+      with_project_config [thrift: [files: []]], fn ->
         assert run([]) == ""
       end
     end
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Compile.ThriftTest do
 
   test "specifying a non-existent Thrift file" do
     in_fixture fn ->
-      with_project_config [thrift_files: ~w("missing.thrift")], fn ->
+      with_project_config [thrift: [files: ~w("missing.thrift")]], fn ->
         capture_io fn ->
           assert run(:stderr, []) =~ "Failed to parse"
         end
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Compile.ThriftTest do
 
   test "specifying an invalid Thrift file" do
     in_fixture fn ->
-      with_project_config [thrift_files: [__ENV__.file]], fn ->
+      with_project_config [thrift: [files: [__ENV__.file]]], fn ->
         capture_io fn ->
           assert run(:stderr, []) =~ "Failed to parse"
         end


### PR DESCRIPTION
This change moves all compiler options under a single top-level `thrift`
configuration key that contains a Keyword list of individual options.
`thrift_files` and `thrift_output` are now just `files` and `output_path`
within this sub-list.

The goal of this change is to tidy up the top-level configuration space
and provide for further expansion of our compiler option set, per #194.