### PR TITLE
Generate `@type t` for structs/unions/exceptions

### DIFF
--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -44,6 +44,7 @@ defmodule Thrift.Generator.StructGenerator do
           end
         end)
         unquote(define_block)
+        @type t :: %__MODULE__{}
         def new, do: %__MODULE__{}
         defmodule BinaryProtocol do
           unquote_splicing(binary_protocol_defs)


### PR DESCRIPTION
It's fairly common to follow a defstruct with a `@type t`.  This is useful for dialyzer analysis and writing specs that convey useful information - e.g.,

```
@spec do_stuff(StructA.t, StructB.t) :: StructC.t
```

This is pretty useful even if we don't specify the types of the fields (in my experience that actually tends to be more trouble than it's worth).

I think eventually we should generate specs and docs for all generated code, but `@type t` is one of the most useful in my experience.