### PR TITLE
Handle unknown (invalid) compiler task options

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Compile.Thrift do
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
-    {opts, _} = OptionParser.parse!(args,
+    {opts, _, _} = OptionParser.parse(args,
       switches: [force: :boolean, verbose: :boolean])
 
     config      = Keyword.get(Mix.Project.config, :thrift, [])

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -81,6 +81,14 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
+  test "specifying an unknown option" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        assert run(["--unknown-option"]) =~ "Compiling"
+      end
+    end
+  end
+
   defp run(args) when is_list(args), do: run(:stdio, args)
   defp run(device, args) when device in [:stdio, :stderr] and is_list(args) do
     args = ["--verbose" | args]


### PR DESCRIPTION
We were still using OptionParser.parse!/1 in the compiler task from back
when we also supported interactive usage. Unfortunately, that function
throws an exception when it encounters an unknown (invalid) option.

Instead, we use OptionParser.parse/1, which allows us to safely discard
invalid options.

Fixes #208 