### PR TITLE
Disable Credo's NoParenthesesWhenZeroArity check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -26,6 +26,7 @@
 
       {Credo.Check.Readability.FunctionNames},
       {Credo.Check.Readability.LargeNumbers, false},
+      {Credo.Check.Readability.NoParenthesesWhenZeroArity, false}, # Fixes a crash in credo 0.6.1
       {Credo.Check.Readability.MaxLineLength, false},
       {Credo.Check.Readability.ModuleAttributeNames},
       {Credo.Check.Readability.ModuleNames},


### PR DESCRIPTION
This appears to crash on some of our code. We'll need to investigation
that separately.