### PR TITLE
Support additional include paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /lib/generated
 /src/thrift_lexer.erl
 /src/thrift_parser.erl
+/test/fixtures/app/_build
 /test/fixtures/app/lib
 /tmp
 erl_crash.dump

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -19,6 +19,8 @@ defmodule Mix.Tasks.Compile.Thrift do
   ## Configuration
 
     * `:files` - list of `.thrift` schema files to compile
+    * `:include_paths` - list of additional directory paths in which to
+      search for included files
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """
@@ -28,13 +30,14 @@ defmodule Mix.Tasks.Compile.Thrift do
     {opts, _, _} = OptionParser.parse(args,
       switches: [force: :boolean, verbose: :boolean])
 
-    config      = Keyword.get(Mix.Project.config, :thrift, [])
-    files       = Keyword.get(config, :files, [])
-    output_path = Keyword.get(config, :output_path, "lib")
+    config        = Keyword.get(Mix.Project.config, :thrift, [])
+    files         = Keyword.get(config, :files, [])
+    include_paths = Keyword.get(config, :include_paths, [])
+    output_path   = Keyword.get(config, :output_path, "lib")
 
     file_groups =
       files
-      |> Enum.map(&parse/1)
+      |> Enum.map(&parse(&1, include_paths))
       |> Enum.reject(&is_nil/1)
 
     stale_groups = Enum.filter(file_groups, fn file_group ->
@@ -48,9 +51,9 @@ defmodule Mix.Tasks.Compile.Thrift do
     end
   end
 
-  defp parse(thrift_file) do
+  defp parse(thrift_file, include_paths) do
     try do
-      Thrift.Parser.parse_file(thrift_file)
+      Thrift.Parser.parse_file(thrift_file, include_paths)
     rescue
       e ->
         Mix.shell.error "Failed to parse #{thrift_file}: #{Exception.message(e)}"

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -6,19 +6,24 @@ defmodule Mix.Tasks.Thrift.Generate do
   @moduledoc """
   Generate Elixir source files from Thrift schema files (`.thrift`).
 
-  A list of files can be given after the task name in order to select the
-  specific Thrift schema files to parse:
+  A list of files should be given after the task name in order to select
+  the specific Thrift schema files to parse:
 
       mix thrift.generate file1.thrift file2.thrift
 
   ## Command line options
 
-    * `-o` `--out` - set the output directory, overriding the `:output_path`
-      configuration value
-    * `-v` `--verbose` - enable verbose task logging
+    * `-I dir` / `--include dir` - add a directory to the list of
+      directory paths in which to search for included files, overriding
+      the `:include_paths` configuration value
+    * `-o dir` / `--out dir` - set the output directory, overriding the
+      `:output_path` configuration value
+    * `-v` / `--verbose` - enable verbose task logging
 
   ## Configuration
 
+    * `:include_paths` - list of additional directory paths in which to
+      search for included files. Defaults to `[]`.
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """
@@ -26,33 +31,36 @@ defmodule Mix.Tasks.Thrift.Generate do
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
     {opts, files} = OptionParser.parse!(args,
-      aliases: [o: :out, v: :verbose],
-      switches: [out: :string, verbose: :boolean])
+      aliases: [I: :include, o: :out, v: :verbose],
+      switches: [include: :keep, out: :string, verbose: :boolean])
 
-    config      = Keyword.get(Mix.Project.config, :thrift, [])
-    output_path = opts[:out] || Keyword.get(config, :output_path, "lib")
+    config        = Keyword.get(Mix.Project.config, :thrift, [])
+    output_path   = opts[:out] || Keyword.get(config, :output_path, "lib")
+    include_paths =
+      (opts[:include] && Keyword.get_values(opts, :include))
+      || Keyword.get(config, :include_paths, [])
 
     unless Enum.empty?(files) do
       File.mkdir_p!(output_path)
-      Enum.each(files, &generate!(&1, output_path, opts))
+      Enum.each(files, &generate!(&1, include_paths, output_path, opts))
     end
   end
 
-  defp parse!(thrift_file) do
+  defp parse!(thrift_file, include_paths) do
     try do
-      Thrift.Parser.parse_file(thrift_file)
+      Thrift.Parser.parse_file(thrift_file, include_paths)
     rescue
       e ->
         Mix.raise "#{thrift_file}: #{Exception.message(e)}"
     end
   end
 
-  defp generate!(thrift_file, output_path, opts) do
+  defp generate!(thrift_file, include_paths, output_path, opts) do
     Mix.shell.info "Parsing #{thrift_file}"
 
     generated_files =
       thrift_file
-      |> parse!
+      |> parse!(include_paths)
       |> Thrift.Generator.generate!(output_path)
 
     if opts[:verbose] do

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -15,7 +15,8 @@ defmodule Mix.Tasks.Thrift.Generate do
 
     * `-I dir` / `--include dir` - add a directory to the list of
       directory paths in which to search for included files, overriding
-      the `:include_paths` configuration value
+      the `:include_paths` configuration value. This option can be repeated
+      in order to add multiple directories to the search list.
     * `-o dir` / `--out dir` - set the output directory, overriding the
       `:output_path` configuration value
     * `-v` / `--verbose` - enable verbose task logging

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -54,15 +54,14 @@ defmodule Thrift.Parser do
   In addition to the given file, all included files are also parsed and
   returned as part of the resulting `Thrift.Parser.FileGroup`.
   """
-  @spec parse_file(Path.t) :: FileGroup.t
-  def parse_file(file_path) do
+  @spec parse_file(Path.t, [Path.t]) :: FileGroup.t
+  def parse_file(file_path, include_paths \\ []) do
     parsed_file = file_path
     |> FileRef.new
     |> ParsedFile.new
 
-    file_group = FileGroup.new(file_path)
+    FileGroup.new(file_path, include_paths)
     |> FileGroup.add(parsed_file)
-
-    FileGroup.update_resolutions(file_group)
+    |> FileGroup.update_resolutions
   end
 end

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -1,7 +1,7 @@
 defmodule Thrift.Parser.FileGroup do
   @moduledoc """
   Represents a group of parsed files.
-  
+
   When you parse a file, it might include other thrift files. These files are
   in turn accumulated and parsed and added to this module. Additionally, this
   module allows resolution of the names of Structs / Enums / Unions etc across
@@ -30,21 +30,26 @@ defmodule Thrift.Parser.FileGroup do
 
   @type t :: %FileGroup{
     initial_file: Path.t,
+    include_paths: [Path.t],
     parsed_files: %{FileRef.thrift_include => %ParsedFile{}},
     schemas: %{FileRef.thrift_include => %Schema{}},
     ns_mappings: %{atom => %Namespace{}}
   }
 
+  @enforce_keys [:initial_file]
   defstruct initial_file: nil,
+            include_paths: [],
             parsed_files: %{},
             schemas: %{},
             resolutions: %{},
             ns_mappings: %{}
 
-  def new(initial_file) do
-    %FileGroup{initial_file: initial_file}
+  @spec new(Path.t, [Path.t]) :: t
+  def new(initial_file, include_paths \\ []) do
+    %FileGroup{initial_file: initial_file, include_paths: include_paths}
   end
 
+  @spec add(t, ParsedFile.t) :: t
   def add(file_group, parsed_file) do
     file_group = add_includes(file_group, parsed_file)
     new_parsed_files = Map.put(file_group.parsed_files, parsed_file.name, parsed_file)
@@ -57,19 +62,29 @@ defmodule Thrift.Parser.FileGroup do
                 resolutions: resolutions}
   end
 
-  def add_includes(%__MODULE__{} = group,
-                   %ParsedFile{schema: schema, file_ref: file_ref}) do
+  defp add_includes(%FileGroup{} = group, %ParsedFile{schema: schema, file_ref: file_ref}) do
+    # Search for included files in the current directory (relative to the
+    # parsed file) as well as any additionally configured include paths.
+    include_paths = [Path.dirname(file_ref.path) | group.include_paths]
 
-    Enum.reduce(schema.includes, group, fn(include, file_group) ->
-      parsed_file = file_ref.path
-      |> Path.dirname
-      |> Path.join(include.path)
-      |> FileRef.new
-      |> ParsedFile.new
-      add(file_group, parsed_file)
+    Enum.reduce(schema.includes, group, fn(include, group) ->
+      parsed_file =
+        include.path
+        |> find_include(include_paths)
+        |> FileRef.new
+        |> ParsedFile.new
+      add(group, parsed_file)
     end)
   end
 
+  # Attempt to locate `path` in one of `dirs`, returning the path of the
+  # first match on success or the original `path` if not match is found.
+  defp find_include(path, dirs) do
+    Enum.map(dirs, &Path.join(&1, path))
+    |> Enum.find(path, &File.exists?/1)
+  end
+
+  @spec update_resolutions(t) :: t
   def update_resolutions(file_group) do
     # since in a file, we can refer to things defined in that file in a non-qualified
     # way, we add unqualified names to the resolutions map.
@@ -92,6 +107,7 @@ defmodule Thrift.Parser.FileGroup do
                ns_mappings: ns_mappings}
   end
 
+  @spec resolve(t, any) :: any
   for type <- [:bool, :byte, :i8, :i16, :i32, :i64, :double, :string, :binary] do
     def resolve(_, unquote(type)), do: unquote(type)
   end
@@ -122,6 +138,7 @@ defmodule Thrift.Parser.FileGroup do
     other
   end
 
+  @spec dest_module(t, any) :: atom
   def dest_module(file_group, %Struct{name: name}) do
     dest_module(file_group, name)
   end

--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -4,6 +4,6 @@ defmodule App.Mixfile do
   def project do
     [app: :app,
      version: "1.0.0",
-     thrift: [files: Path.wildcard("thrift/**/*.thrift")]]
+     thrift: [files: ~w(thrift/StressTest.thrift thrift/ThriftTest.thrift)]]
   end
 end

--- a/test/fixtures/app/thrift/include/Include.thrift
+++ b/test/fixtures/app/thrift/include/Include.thrift
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+include "ThriftTest.thrift"
+
+namespace elixir Include
+
+struct IncludeTest {
+  1: required ThriftTest.Bools bools
+}

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -80,6 +80,18 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
+  test "specifying an additional include path" do
+    config = [
+      files: ~w(thrift/include/Include.thrift),
+      include_paths: ~w(thrift)
+    ]
+    in_fixture fn ->
+      with_project_config [thrift: config], fn ->
+        assert run([]) =~ "Compiled thrift/include/Include.thrift"
+      end
+    end
+  end
+
   test "specifying an unknown option" do
     in_fixture fn ->
       with_project_config [], fn ->

--- a/test/mix/tasks/thrift.generate_test.exs
+++ b/test/mix/tasks/thrift.generate_test.exs
@@ -49,6 +49,13 @@ defmodule Mix.Tasks.Thrift.GenerateTest do
     end
   end
 
+  test "specifying an include path (--include)" do
+    in_fixture fn ->
+      run(~w(--include thrift thrift/include/Include.thrift))
+      assert File.exists?("lib/thrift_test/thrift_test.ex")
+    end
+  end
+
   defp run(args) when is_list(args), do: run(:stdio, args)
   defp run(device, args) when device in [:stdio, :stderr] and is_list(args) do
     args = ["--verbose" | args]


### PR DESCRIPTION
We previously only supported including other Thrift files whose
pathnames were relative to the current file. This change allows a list
of additional include (search) paths to be specified as part of the
project configuration (`thrift.include_paths`) or via a command line
option (`--include dir`).

Closes #188