### PR TITLE
Remove the numbers.thrift test file

### DIFF
--- a/test/fixtures/app/mix.exs
+++ b/test/fixtures/app/mix.exs
@@ -7,8 +7,7 @@ defmodule App.Mixfile do
      thrift: [
        files: [
          "thrift/StressTest.thrift",
-         "thrift/ThriftTest.thrift",
-         "thrift/numbers.thrift"
+         "thrift/ThriftTest.thrift"
        ]
      ]]
   end

--- a/test/fixtures/app/thrift/numbers.thrift
+++ b/test/fixtures/app/thrift/numbers.thrift
@@ -1,4 +1,0 @@
-// making sure that a file of constants will compile
-namespace elixir Tutorial
-
-const i32 one = 1

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -14,14 +14,12 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     in_fixture fn ->
       with_project_config [], fn ->
         assert run([]) =~ """
-          Compiling 3 files (.thrift)
+          Compiling 2 files (.thrift)
           Compiled thrift/StressTest.thrift
           Compiled thrift/ThriftTest.thrift
-          Compiled thrift/numbers.thrift
           """
         assert File.exists?("lib/stress/service.ex")
         assert File.exists?("lib/thrift_test/thrift_test.ex")
-        assert File.exists?("lib/tutorial/numbers.ex")
       end
     end
   end


### PR DESCRIPTION
The new ThriftTest.thrift includes constants, so numbers.thrift is now
redundant.