### PR TITLE
Generalize the set of Parser.opts

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -32,12 +32,12 @@ defmodule Mix.Tasks.Compile.Thrift do
 
     config        = Keyword.get(Mix.Project.config, :thrift, [])
     files         = Keyword.get(config, :files, [])
-    include_paths = Keyword.get(config, :include_paths, [])
     output_path   = Keyword.get(config, :output_path, "lib")
+    parser_opts   = Keyword.take(config, [:include_paths])
 
     file_groups =
       files
-      |> Enum.map(&parse(&1, include_paths))
+      |> Enum.map(&parse(&1, parser_opts))
       |> Enum.reject(&is_nil/1)
 
     stale_groups = Enum.filter(file_groups, fn file_group ->
@@ -51,9 +51,9 @@ defmodule Mix.Tasks.Compile.Thrift do
     end
   end
 
-  defp parse(thrift_file, include_paths) do
+  defp parse(thrift_file, opts) do
     try do
-      Thrift.Parser.parse_file(thrift_file, include_paths)
+      Thrift.Parser.parse_file(thrift_file, opts)
     rescue
       e ->
         Mix.shell.error "Failed to parse #{thrift_file}: #{Exception.message(e)}"

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -41,27 +41,31 @@ defmodule Mix.Tasks.Thrift.Generate do
       (opts[:include] && Keyword.get_values(opts, :include))
       || Keyword.get(config, :include_paths, [])
 
+    parser_opts =
+      Keyword.new
+      |> Keyword.put(:include_paths, include_paths)
+
     unless Enum.empty?(files) do
       File.mkdir_p!(output_path)
-      Enum.each(files, &generate!(&1, include_paths, output_path, opts))
+      Enum.each(files, &generate!(&1, output_path, parser_opts, opts))
     end
   end
 
-  defp parse!(thrift_file, include_paths) do
+  defp parse!(thrift_file, opts) do
     try do
-      Thrift.Parser.parse_file(thrift_file, include_paths)
+      Thrift.Parser.parse_file(thrift_file, opts)
     rescue
       e ->
         Mix.raise "#{thrift_file}: #{Exception.message(e)}"
     end
   end
 
-  defp generate!(thrift_file, include_paths, output_path, opts) do
+  defp generate!(thrift_file, output_path, parser_opts, opts) do
     Mix.shell.info "Parsing #{thrift_file}"
 
     generated_files =
       thrift_file
-      |> parse!(include_paths)
+      |> parse!(parser_opts)
       |> Thrift.Generator.generate!(output_path)
 
     if opts[:verbose] do

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -3,11 +3,15 @@ defmodule Thrift.Parser do
   This module provides functions for parsing Thrift IDL files (`.thrift`).
   """
 
+  alias Thrift.Parser.{FileGroup, FileRef, Models, ParsedFile}
+  alias Thrift.Parser.Models.Schema
+
   @typedoc "A schema path element"
   @type path_element :: String.t | atom
 
-  alias Thrift.Parser.{FileGroup, FileRef, Models, ParsedFile}
-  alias Thrift.Parser.Models.Schema
+  @typedoc "Available parser options"
+  @type opt :: {:include_paths, [Path.t]}
+  @type opts :: [opt]
 
   @doc """
   Parses a Thrift document and returns the schema that it represents.
@@ -54,13 +58,13 @@ defmodule Thrift.Parser do
   In addition to the given file, all included files are also parsed and
   returned as part of the resulting `Thrift.Parser.FileGroup`.
   """
-  @spec parse_file(Path.t, [Path.t]) :: FileGroup.t
-  def parse_file(file_path, include_paths \\ []) do
+  @spec parse_file(Path.t, opts) :: FileGroup.t
+  def parse_file(file_path, opts \\ []) do
     parsed_file = file_path
     |> FileRef.new
     |> ParsedFile.new
 
-    FileGroup.new(file_path, include_paths)
+    FileGroup.new(file_path, opts)
     |> FileGroup.add(parsed_file)
     |> FileGroup.update_resolutions
   end


### PR DESCRIPTION
The introduction of include_paths made me realize that adding more
parser options (e.g. namespace configuration) would become unwieldy.

This change generalizes parser options as a keyword list with formal
type definitions for supported values. At the moment, `:include_paths` is
the only option, but it's now much more obvious how to add new ones.