### PR TITLE
Handle name collisions of different types, allow constants to live beside structs/etc

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -93,7 +93,7 @@ defmodule Thrift.Generator do
       filename
     end)
   end
-  
+
   defp resolve_name_collisions(generated_modules) do
     Enum.reduce(generated_modules, [], fn({name, quoted}, acc) ->
       Keyword.update(

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -77,7 +77,7 @@ defmodule Thrift.Generator.Utils do
     a |> Atom.to_string |> underscore |> String.to_atom
   end
 
-  # NOTE 
+  # NOTE
   # this is basically the same as Macro.underscore/1, but this version properly
   # handles SCREAMING_SNAKE_CASE strings
   # Macro.underscore/1 has been fixed upstream in the Elixir source

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -77,7 +77,10 @@ defmodule Thrift.Generator.Utils do
     a |> Atom.to_string |> underscore |> String.to_atom
   end
 
-  # NOTE this properly handles SCREAMING_SNAKE_CASE strings
+  # NOTE 
+  # this is basically the same as Macro.underscore/1, but this version properly
+  # handles SCREAMING_SNAKE_CASE strings
+  # Macro.underscore/1 has been fixed upstream in the Elixir source
   @spec underscore(binary) :: binary
   def underscore(s) when is_binary(s) do
     s

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -77,8 +77,14 @@ defmodule Thrift.Generator.Utils do
     a |> Atom.to_string |> underscore |> String.to_atom
   end
 
+  # NOTE this properly handles SCREAMING_SNAKE_CASE strings
   @spec underscore(binary) :: binary
-  def underscore(s) when is_bitstring(s), do: Macro.underscore(s)
+  def underscore(s) when is_binary(s) do
+    s
+    |> String.split("_")
+    |> Enum.map(&Macro.underscore/1)
+    |> Enum.join("_")
+  end
 
   # Change this to true to see iolist optimizations as they are applied.
   @debug_optimization false

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -4,8 +4,6 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   alias Thrift.Protocol.Binary
   alias Thrift.Union.TooManyFieldsSetException
 
-  @thrift_test_opts [cleanup: false]
-
   def assert_serializes(%{__struct__: mod} = struct, binary) do
     assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
     assert {^struct, ""} = mod.deserialize(binary)

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -4,6 +4,8 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   alias Thrift.Protocol.Binary
   alias Thrift.Union.TooManyFieldsSetException
 
+  @thrift_test_opts [cleanup: false]
+
   def assert_serializes(%{__struct__: mod} = struct, binary) do
     assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
     assert {^struct, ""} = mod.deserialize(binary)
@@ -536,6 +538,33 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert struct.empty_set == MapSet.new
     assert struct.empty_list == []
     :ok
+  end
+
+  @thrift_file name: "x_man.thrift", contents: """
+  enum PowerLevel {
+    ALPHA,
+    BETA,
+    OMEGA
+  }
+
+  const string EARTH_616 = "Earth-616"
+
+  struct XMan{
+    1: string handle
+    2: string name
+    3: string universe = EARTH_616
+    4: PowerLevel power_level
+  }
+
+
+  const XMan Wolverine = {"handle": "Wolverine", "name": "Logan", "power_level": BETA}
+  const XMan Cyclops = {"handle": "Cyclops", "name": "Scott Summers", "power_level": BETA}
+  const XMan Storm = {"handle": "Storm", "name": "Ororo Monroe", "power_level": ALPHA}
+  const XMan Phoenix = {"handle": "Phoenix", "name": "Jean Grey", "power_level": OMEGA}
+  """
+
+  thrift_test "constants and structs defined in the same file" do
+    assert %XMan{} = XMan.wolverine
   end
 
   thrift_test "lists serialize into maps" do

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -554,15 +554,25 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     4: PowerLevel power_level
   }
 
-
-  const XMan Wolverine = {"handle": "Wolverine", "name": "Logan", "power_level": BETA}
-  const XMan Cyclops = {"handle": "Cyclops", "name": "Scott Summers", "power_level": BETA}
-  const XMan Storm = {"handle": "Storm", "name": "Ororo Monroe", "power_level": ALPHA}
-  const XMan Phoenix = {"handle": "Phoenix", "name": "Jean Grey", "power_level": OMEGA}
+  const XMan Wolverine = {"handle": "Wolverine", "name": "Logan", "power_level": PowerLevel.BETA}
+  const XMan Cyclops = {"handle": "Cyclops", "name": "Scott Summers", "power_level": PowerLevel.BETA}
+  const XMan Storm = {"handle": "Storm", "name": "Ororo Monroe", "power_level": PowerLevel.ALPHA}
+  const XMan Phoenix = {"handle": "Phoenix", "name": "Jean Grey", "power_level": PowerLevel.OMEGA}
   """
 
   thrift_test "constants and structs defined in the same file" do
-    assert %XMan{} = XMan.wolverine
+    assert %XMan{
+      handle: "Wolverine", name: "Logan", power_level: PowerLevel.beta, universe: XMan.earth_616
+    } == XMan.wolverine
+    assert %XMan{
+      handle: "Cyclops", name: "Scott Summers", power_level: PowerLevel.beta, universe: XMan.earth_616
+    } == XMan.cyclops
+    assert %XMan{
+      handle: "Storm", name: "Ororo Monroe", power_level: PowerLevel.alpha, universe: XMan.earth_616
+    } == XMan.storm
+    assert %XMan{
+      handle: "Phoenix", name: "Jean Grey", power_level: PowerLevel.omega, universe: XMan.earth_616
+    } == XMan.phoenix
   end
 
   thrift_test "lists serialize into maps" do


### PR DESCRIPTION
Also fix a bug in Utils.underscore (it's fixed upstream in the Elixir source but we probably want to support some of the existing Elixir versions).

This is re: #220 and could potentially also resolve #185 - I'm not sure how to test the assertion on name collisions within our test framework, though.
