### PR TITLE
Set `async: true` for compatible tests

### DIFF
--- a/test/thrift/generator/utils_test.exs
+++ b/test/thrift/generator/utils_test.exs
@@ -1,5 +1,5 @@
 defmodule Thrift.Generator.UtilsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import Thrift.Generator.Utils
 
   defmacro check(input, expected_output) do

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -1,6 +1,6 @@
 defmodule BinaryProtocolTest do
   use ThriftTestCase, gen_erl: true
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Thrift.Protocol.Binary
 


### PR DESCRIPTION
These tests can run asynchronously because they don't do any file IO.
This change speeds up our unit test times by a small amount.