### PR TITLE
Allow the namespace option to be a string or module

### DIFF
--- a/test/thrift/parser_test.exs
+++ b/test/thrift/parser_test.exs
@@ -694,7 +694,7 @@ defmodule ParserTest do
       1: i32 id
     }
     """
-    
+
     path = Path.join(@test_file_dir, "get_namespaced.thrift")
     File.write!(path, contents)
 

--- a/test/thrift/parser_test.exs
+++ b/test/thrift/parser_test.exs
@@ -2,7 +2,7 @@ defmodule ParserTest do
   use ExUnit.Case, async: true
 
   @project_root Path.expand("../..", __DIR__)
-  @test_file_dir Path.join([@project_root, "tmp", "parser_error"])
+  @test_file_dir Path.join([@project_root, "tmp", "parser_test"])
 
   import Thrift.Parser, only: [parse: 1, parse: 2, parse_file: 2]
 
@@ -22,7 +22,7 @@ defmodule ParserTest do
 
   import ExUnit.CaptureIO
 
-  setup do
+  setup_all do
     File.rm_rf!(@test_file_dir)
     File.mkdir_p!(@test_file_dir)
     on_exit fn -> File.rm_rf!(@test_file_dir) end


### PR DESCRIPTION
Also normalize it before use - someone could put in "foo" and we need "Foo" so I put in a `Macro.camelize`.

This came up for me when I went to use the new option and it wasn't clear if `namespace` should be a string or a module.  This makes it so either is OK.  I could be convinced that we should be more strict and require a string, but if we do that then I think we should a) make the help text/docs clear on that, and b) raise an error saying that the input is invalid if it's either not a string or if it's not a CamelCase string.  If that's preferable, I could pivot this PR to do that pretty easily I think.