### PR TITLE
Handle constants clobbering other modules or double-defining

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -163,9 +163,15 @@ defmodule Thrift.Generator do
     |> Map.values
     |> Enum.filter(&FileGroup.own_constant?(schema.file_group, &1))
 
-    # name of the generated module
-    full_name = FileGroup.dest_module(schema.file_group, Constant)
-    [{full_name, ConstantGenerator.generate(full_name, constants, schema)}]
+    if Enum.empty?(constants) do
+      # if we filtered out all of the constants, we don't need to write
+      # anything
+      []
+    else
+      # name of the generated module
+      full_name = FileGroup.dest_module(schema.file_group, Constant)
+      [{full_name, ConstantGenerator.generate(full_name, constants, schema)}]
+    end
   end
 
   defp generate_struct_modules(schema) do

--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -156,7 +156,13 @@ defmodule Thrift.Generator do
   defp generate_const_modules(schema) do
     # schema.constants is a map %{name: constant} but constant includes the
     # name and all we really need is the values
-    constants = Map.values(schema.constants)
+    # 
+    # we also only want constants that are defined in the main file from this
+    # file group
+    constants = schema.constants
+    |> Map.values
+    |> Enum.filter(&FileGroup.own_constant?(schema.file_group, &1))
+
     # name of the generated module
     full_name = FileGroup.dest_module(schema.file_group, Constant)
     [{full_name, ConstantGenerator.generate(full_name, constants, schema)}]

--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -156,7 +156,7 @@ defmodule Thrift.Generator do
   defp generate_const_modules(schema) do
     # schema.constants is a map %{name: constant} but constant includes the
     # name and all we really need is the values
-    # 
+    #
     # we also only want constants that are defined in the main file from this
     # file group
     constants = schema.constants

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -197,7 +197,7 @@ defmodule Thrift.Parser.FileGroup do
   #   this should eventually be replaced if we find a way to only parse files
   #   once
   @spec own_constant?(t, Constant.t) :: boolean
-  def own_constant?(file_group, constant = %Constant{}) do
+  def own_constant?(file_group, %Constant{} = constant) do
     basename = Path.basename(file_group.initial_file, ".thrift")
     initial_file = file_group.parsed_files[basename]
     Enum.member?(Map.keys(initial_file.schema.constants), constant.name)

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -193,6 +193,16 @@ defmodule Thrift.Parser.FileGroup do
     end
   end
 
+  # check if the given model is defined in the root file of the file group
+  #   this should eventually be replaced if we find a way to only parse files
+  #   once
+  @spec own_constant?(t, Constant.t) :: boolean
+  def own_constant?(file_group, constant = %Constant{}) do
+    basename = Path.basename(file_group.initial_file, ".thrift")
+    initial_file = file_group.parsed_files[basename]
+    Enum.member?(Map.keys(initial_file.schema.constants), constant.name)
+  end
+
   defp build_ns_mappings(schemas, default_namespace) do
     schemas
     |> Enum.map(fn {module_name, %Schema{namespaces: ns}} ->

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -575,6 +575,24 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     } == XMan.phoenix
   end
 
+  @thrift_file name: "included_constants.thrift", contents: """
+  const i8 Z = 26
+  """
+
+  @thrift_file name: "includes_constants.thrift", contents: """
+  include "included_constants.thrift"
+
+  struct IncludesConstants {
+    1: string name
+    2: i8 z = included_constants.Z
+  }
+  """
+
+  thrift_test "including a file with constants" do
+    assert 26 == IncludedConstants.z
+    assert %IncludesConstants{z: 26} == %IncludesConstants{}
+  end
+
   thrift_test "lists serialize into maps" do
     binary = <<13, 0, 2, 3, 3, 0, 0, 0, 1, 91, 92, 0>>
     assert binary == %Byte{val_map: %{91 => 92}} |> Byte.serialize() |> IO.iodata_to_binary

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -601,7 +601,9 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert %IncludesConstants{z: 26} == %IncludesConstants{}
     assert_raise UndefinedFunctionError, fn -> 26 == IncludesConstants.z end
     assert %SomeOtherName{} == SomeOtherName.new()
-    assert_raise UndefinedFunctionError, fn -> 26 == AlsoIncludes.z end
+    assert Code.ensure_loaded?(IncludedConstants)
+    # AlsoIncludes should not define anything
+    refute Code.ensure_loaded?(AlsoIncludes)
   end
 
   thrift_test "lists serialize into maps" do

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -588,9 +588,20 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   }
   """
 
+  @thrift_file name: "also_includes.thrift", contents: """
+  include "included_constants.thrift"
+
+  struct SomeOtherName {
+    1: i32 id
+  }
+  """
+
   thrift_test "including a file with constants" do
     assert 26 == IncludedConstants.z
     assert %IncludesConstants{z: 26} == %IncludesConstants{}
+    assert_raise UndefinedFunctionError, fn -> 26 == IncludesConstants.z end
+    assert %SomeOtherName{} == SomeOtherName.new()
+    assert_raise UndefinedFunctionError, fn -> 26 == AlsoIncludes.z end
   end
 
   thrift_test "lists serialize into maps" do


### PR DESCRIPTION
Re: discussion on #227 this is a "quick fix" that should handle the more immediate concerns.

I think it's still possible we could end up clobbering modules in general if more than one thrift file defines the same 'object', but I think that's a more insidious edge case at least.