### PR TITLE
Serializer / Deserializer do not respect signedness

### DIFF
--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -112,14 +112,14 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp field_deserializer(:i16, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(Type.i16), unquote(field.id)::16-signed, value::size(16), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i16), unquote(field.id)::16-signed, value::16-signed, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
   end
   defp field_deserializer(:i32, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(Type.i32), unquote(field.id)::16-signed, value::size(32), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i32), unquote(field.id)::16-signed, value::32-signed, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
@@ -129,7 +129,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp field_deserializer(:i64, field, name, _file_group) do
     quote do
-      defp unquote(name)(<<unquote(Type.i64), unquote(field.id)::16-signed, value::size(64), rest::binary>>, acc) do
+      defp unquote(name)(<<unquote(Type.i64), unquote(field.id)::16-signed, value::64-signed, rest::binary>>, acc) do
         unquote(name)(rest, %{acc | unquote(field.name) => value})
       end
     end
@@ -196,7 +196,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
                            unquote(field.id)::16-signed,
                            unquote(type_id(key_type, file_group)),
                            unquote(type_id(value_type, file_group)),
-                           map_size::size(32),
+                           map_size::32-signed,
                            rest::binary>>, struct) do
         unquote(key_name)(rest, [%{}, map_size, struct])
       end
@@ -277,14 +277,14 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp map_key_deserializer(:i16, key_name, value_name, _file_group) do
     quote do
-      defp unquote(key_name)(<<key::size(16), rest::binary>>, stack) do
+      defp unquote(key_name)(<<key::16-signed, rest::binary>>, stack) do
         unquote(value_name)(rest, key, stack)
       end
     end
   end
   defp map_key_deserializer(:i32, key_name, value_name, _file_group) do
     quote do
-      defp unquote(key_name)(<<key::size(32), rest::binary>>, stack) do
+      defp unquote(key_name)(<<key::32-signed, rest::binary>>, stack) do
         unquote(value_name)(rest, key, stack)
       end
     end
@@ -294,7 +294,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp map_key_deserializer(:i64, key_name, value_name, _file_group) do
     quote do
-      defp unquote(key_name)(<<key::size(64), rest::binary>>, stack) do
+      defp unquote(key_name)(<<key::64-signed, rest::binary>>, stack) do
         unquote(value_name)(rest, key, stack)
       end
     end
@@ -426,14 +426,14 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp map_value_deserializer(:i16, key_name, value_name, _file_group) do
     quote do
-      defp unquote(value_name)(<<value::size(16), rest::binary>>, key, [map, remaining | stack]) do
+      defp unquote(value_name)(<<value::16-signed, rest::binary>>, key, [map, remaining | stack]) do
         unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
       end
     end
   end
   defp map_value_deserializer(:i32, key_name, value_name, _file_group) do
     quote do
-      defp unquote(value_name)(<<value::size(32), rest::binary>>, key, [map, remaining | stack]) do
+      defp unquote(value_name)(<<value::32-signed, rest::binary>>, key, [map, remaining | stack]) do
         unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
       end
     end
@@ -443,7 +443,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp map_value_deserializer(:i64, key_name, value_name, _file_group) do
     quote do
-      defp unquote(value_name)(<<value::size(64), rest::binary>>, key, [map, remaining | stack]) do
+      defp unquote(value_name)(<<value::64-signed, rest::binary>>, key, [map, remaining | stack]) do
         unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
       end
     end
@@ -571,21 +571,21 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp list_deserializer(:i8, name, _file_group) do
     quote do
-      defp unquote(name)(<<element::size(8), rest::binary>>, [list, remaining | stack]) do
+      defp unquote(name)(<<element::8-signed, rest::binary>>, [list, remaining | stack]) do
         unquote(name)(rest, [[element | list], remaining - 1 | stack])
       end
     end
   end
   defp list_deserializer(:i16, name, _file_group) do
     quote do
-      defp unquote(name)(<<element::size(16), rest::binary>>, [list, remaining | stack]) do
+      defp unquote(name)(<<element::16-signed, rest::binary>>, [list, remaining | stack]) do
         unquote(name)(rest, [[element | list], remaining - 1 | stack])
       end
     end
   end
   defp list_deserializer(:i32, name, _file_group) do
     quote do
-      defp unquote(name)(<<element::size(32), rest::binary>>, [list, remaining | stack]) do
+      defp unquote(name)(<<element::32-signed, rest::binary>>, [list, remaining | stack]) do
         unquote(name)(rest, [[element | list], remaining - 1 | stack])
       end
     end
@@ -595,7 +595,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   end
   defp list_deserializer(:i64, name, _file_group) do
     quote do
-      defp unquote(name)(<<element::size(64), rest::binary>>, [list, remaining | stack]) do
+      defp unquote(name)(<<element::64-signed, rest::binary>>, [list, remaining | stack]) do
         unquote(name)(rest, [[element | list], remaining - 1 | stack])
       end
     end

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -113,7 +113,9 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert_serializes %I16{val: 1},                     <<6, 0, 1, 0, 1, 0>>
     assert_serializes %I16{val: 255},                   <<6, 0, 1, 0, 255, 0>>
     assert_serializes %I16{val: 256},                   <<6, 0, 1, 1, 0, 0>>
-    assert_serializes %I16{val: 65535},                 <<6, 0, 1, 255, 255, 0>>
+    assert_serializes %I16{val: 32767},                 <<6, 0, 1, 127, 255, 0>>
+    assert_serializes %I16{val: -1},                    <<6, 0, 1, 255, 255, 0>>
+    assert_serializes %I16{val: -32768},                <<6, 0, 1, 128, 0, 0>>
     assert_serializes %I16{val: 65536},                 <<6, 0, 1, 0, 0, 0>>, %I16{val: 0}
     assert_serializes %I16{val_map: %{}},               <<13, 0, 2, 6, 6, 0, 0, 0, 0, 0>>
     assert_serializes %I16{val_map: %{91 => 92}},       <<13, 0, 2, 6, 6, 0, 0, 0, 1, 0, 91, 0, 92, 0>>
@@ -141,6 +143,9 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert_serializes %I32{val: 255},                   <<8, 0, 1, 0, 0, 0, 255, 0>>
     assert_serializes %I32{val: 256},                   <<8, 0, 1, 0, 0, 1, 0, 0>>
     assert_serializes %I32{val: 65535},                 <<8, 0, 1, 0, 0, 255, 255, 0>>
+    assert_serializes %I32{val: 2_147_483_647},         <<8, 0, 1, 127, 255, 255, 255, 0>>
+    assert_serializes %I32{val: -2_147_483_648},        <<8, 0, 1, 128, 0, 0, 0, 0>>
+    assert_serializes %I32{val: -1},                    <<8, 0, 1, 255, 255, 255, 255, 0>>
     assert_serializes %I32{val_map: %{}},               <<13, 0, 2, 8, 8, 0, 0, 0, 0, 0>>
     assert_serializes %I32{val_map: %{91 => 92}},       <<13, 0, 2, 8, 8, 0, 0, 0, 1, 0, 0, 0, 91, 0, 0, 0, 92, 0>>
     assert_serializes %I32{val_set: MapSet.new},        <<14, 0, 3, 8, 0, 0, 0, 0, 0>>
@@ -160,12 +165,18 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   """
 
   thrift_test "i64 serialization" do
+    i64_max = 9_223_372_036_854_775_807
+    i64_min = -9_223_372_036_854_775_808
+
     assert_serializes %I64{},                           <<0>>
     assert_serializes %I64{val: 0},                     <<10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
     assert_serializes %I64{val: 1},                     <<10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0>>
     assert_serializes %I64{val: 255},                   <<10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 255, 0>>
     assert_serializes %I64{val: 256},                   <<10, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0>>
     assert_serializes %I64{val: 65535},                 <<10, 0, 1, 0, 0, 0, 0, 0, 0, 255, 255, 0>>
+    assert_serializes %I64{val: i64_min},               <<10, 0, 1, 128, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert_serializes %I64{val: i64_max},               <<10, 0, 1, 127, 255, 255, 255, 255, 255, 255, 255, 0>>
+    assert_serializes %I64{val: -1},                    <<10, 0, 1, 255, 255, 255, 255, 255, 255, 255, 255, 0>>
     assert_serializes %I64{val_map: %{}},               <<13, 0, 2, 10, 10, 0, 0, 0, 0, 0>>
     assert_serializes %I64{val_map: %{91 => 92}},       <<13, 0, 2, 10, 10, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 92, 0>>
     assert_serializes %I64{val_set: MapSet.new},        <<14, 0, 3, 10, 0, 0, 0, 0, 0>>


### PR DESCRIPTION
We were using size(x) rather than x-signed; apparently, size(x) is for
unsigned numbers.

Fixed, and added unit tests for boundary conditions. Fixes #206