### PR TITLE
Maintain a manifest of generated files

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -118,11 +118,13 @@ defmodule Mix.Tasks.Compile.Thrift do
       File.mkdir_p!(output_path)
       Enum.each(removed, &File.rm/1)
 
-      Mix.Utils.compiling_n(length(stale), :thrift)
-      Enum.each(stale, fn {group, _targets} ->
-        Thrift.Generator.generate!(group, output_path)
-        verbose && Mix.shell.info "Compiled #{group.initial_file}"
-      end)
+      unless Enum.empty?(stale) do
+        Mix.Utils.compiling_n(length(stale), :thrift)
+        Enum.each(stale, fn {group, _targets} ->
+          Thrift.Generator.generate!(group, output_path)
+          verbose && Mix.shell.info "Compiled #{group.initial_file}"
+        end)
+      end
 
       # Update and rewrite the manifest.
       entries = (previous -- removed) ++ Enum.flat_map(stale, &elem(&1, 1))

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -38,17 +38,17 @@ defmodule Mix.Tasks.Compile.Thrift do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 
     config      = Keyword.get(Mix.Project.config, :thrift, [])
-    files       = Keyword.get(config, :files, [])
+    input_files = Keyword.get(config, :files, [])
     output_path = Keyword.get(config, :output_path, "lib")
     parser_opts = Keyword.take(config, [:include_paths, :namespace])
 
-    targets =
-      files
+    mappings =
+      input_files
       |> Enum.map(&parse(&1, parser_opts))
       |> Enum.reject(&is_nil/1)
       |> extract_targets(output_path, opts[:force])
 
-    generate(manifest(), targets, output_path, opts)
+    generate(manifest(), mappings, output_path, opts)
   end
 
   @doc "Returns the Thrift compiler's manifests."
@@ -65,12 +65,12 @@ defmodule Mix.Tasks.Compile.Thrift do
   end
 
   @spec parse(Path.t, OptionParser.parsed) :: FileGroup.t
-  defp parse(thrift_file, opts) do
+  defp parse(file, opts) do
     try do
-      Thrift.Parser.parse_file(thrift_file, opts)
+      Thrift.Parser.parse_file(file, opts)
     rescue
       e ->
-        Mix.shell.error "Failed to parse #{thrift_file}: #{Exception.message(e)}"
+        Mix.shell.error "Failed to parse #{file}: #{Exception.message(e)}"
         nil
     end
   end

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Compile.Thrift do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 
     config      = Keyword.get(Mix.Project.config, :thrift, [])
-    files       = Keyword.get(config, :files, ["./test/fixtures/app/thrift/StressTest.thrift"])
+    files       = Keyword.get(config, :files, [])
     output_path = Keyword.get(config, :output_path, "lib")
     parser_opts = Keyword.take(config, [:include_paths, :namespace])
 

--- a/test/mix/tasks/compile.thrift_test.exs
+++ b/test/mix/tasks/compile.thrift_test.exs
@@ -54,6 +54,20 @@ defmodule Mix.Tasks.Compile.ThriftTest do
     end
   end
 
+  test "cleaning generated files" do
+    in_fixture fn ->
+      with_project_config [], fn ->
+        run([])
+        assert File.exists?("lib/thrift_test/thrift_test.ex")
+        assert Enum.all?(Mix.Tasks.Compile.Thrift.manifests, &File.exists?/1)
+
+        Mix.Tasks.Compile.Thrift.clean()
+        refute File.exists?("lib/thrift_test/thrift_test.ex")
+        refute Enum.any?(Mix.Tasks.Compile.Thrift.manifests, &File.exists?/1)
+      end
+    end
+  end
+
   test "specifying an empty :files list" do
     in_fixture fn ->
       with_project_config [thrift: [files: []]], fn ->


### PR DESCRIPTION
This is signifiant rewrite of the compiler task to support manifests,
making us a better mix citizen and adding support for `mix clean`-based
file cleanup.

Our manifest is written as a binary-encoded Erlang term to give us the
most forward-compatible file format. At the moment, we only store a
manifest version number and the list of generated files, but we may
expand this in the future to include additional dependency information
such as the "version" of the code that was used to generate these files.
See #138 for a more detailed discussion.