### PR TITLE
Include our package version in the manifest header

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -133,21 +133,29 @@ defmodule Mix.Tasks.Compile.Thrift do
     end
   end
 
+  defp thrift_vsn do
+    Keyword.get(Mix.Project.config, :version)
+  end
+
   @spec read_manifest(Path.t) :: [Path.t]
   defp read_manifest(manifest) do
+    header = {@manifest_vsn, thrift_vsn()}
     try do
       manifest |> File.read! |> :erlang.binary_to_term
     rescue
       _ -> []
     else
-      [@manifest_vsn | paths] -> paths
+      [^header | paths] -> paths
       _ -> []
     end
   end
 
   @spec write_manifest(Path.t, [Path.t], :calendar.datetime) :: :ok
   defp write_manifest(manifest, paths, timestamp) do
-    data = [@manifest_vsn | paths] |> :erlang.term_to_binary(compressed: 9)
+    data =
+      [{@manifest_vsn, thrift_vsn()} | paths]
+      |> :erlang.term_to_binary(compressed: 9)
+
     Path.dirname(manifest) |> File.mkdir_p!
     File.write!(manifest, data)
     File.touch!(manifest, timestamp)

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -133,13 +133,13 @@ defmodule Mix.Tasks.Compile.Thrift do
     end
   end
 
-  defp thrift_vsn do
+  defp package_vsn do
     Keyword.get(Mix.Project.config, :version)
   end
 
   @spec read_manifest(Path.t) :: [Path.t]
   defp read_manifest(manifest) do
-    header = {@manifest_vsn, thrift_vsn()}
+    header = {@manifest_vsn, package_vsn()}
     try do
       manifest |> File.read! |> :erlang.binary_to_term
     rescue
@@ -153,7 +153,7 @@ defmodule Mix.Tasks.Compile.Thrift do
   @spec write_manifest(Path.t, [Path.t], :calendar.datetime) :: :ok
   defp write_manifest(manifest, paths, timestamp) do
     data =
-      [{@manifest_vsn, thrift_vsn()} | paths]
+      [{@manifest_vsn, package_vsn()} | paths]
       |> :erlang.term_to_binary(compressed: 9)
 
     Path.dirname(manifest) |> File.mkdir_p!


### PR DESCRIPTION
This gives us additional control over when to consider existing
artifacts as "stale" and in need of regeneration. At the moment, we
require a strict version string match, but as we mature in accordance
with semver guidelines, we can switch to a more fine-grained approach
based on Version.compare/2.

We don't need to bump the manifest version in this case because ...

1. Reads against existing manifests will safely fail and result in
   desirable rebuild behavior.
2. The manifest stuff is brand new, and it's unlike many folks are
   using it yet.