### PR TITLE
Revise our Dialyzer configuration

### DIFF
--- a/.dialyzerignore
+++ b/.dialyzerignore
@@ -1,0 +1,1 @@
+Function yyrev/2 will never be called

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,10 @@ defmodule Thrift.Mixfile do
      package: package(),
 
      # Dialyzer
-     dialyzer: [plt_add_deps: :transitive, plt_add_apps: [:ex_unit, :mix, :public_key, :ssl]],
+     dialyzer: [
+       plt_add_deps: :transitive,
+       plt_add_apps: [:mix],
+       ignore_warnings: ".dialyzerignore"],
 
      # Docs
      name: "Thrift",

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "dialyxir": {:hex, :dialyxir, "0.4.0", "53ac3014bb4aef647728a697052b4db3a84c6742de7aab0e0a1c863ea274007b", [:mix], []},
+  "dialyxir": {:hex, :dialyxir, "0.4.4", "e93ff4affc5f9e78b70dc7bec7b07da44ae1ed3fef38e7113568dd30ad7b01d3", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
This upgrades dialyxir, simplifies the set of included apps, and adds an
"ignore" rule for the leex-related warning that we otherwise can't
control.