### PR TITLE
Connections couldn't be closed

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -158,13 +158,16 @@ defmodule Thrift.Binary.Framed.Client do
     case info do
       {:close, from} ->
         Connection.reply(from, :ok)
+        {:stop, :normal, nil}
 
       {:error, :closed} ->
         Logger.error("Connection closed")
+        {:connect, info, %{s | sock: nil}}
 
       {:error, reason} ->
         reason = :inet.format_error(reason)
         Logger.error("Connection error: #{reason}")
+        {:connect, info, %{s | sock: nil}}
 
       {:retry, _} ->
         case s.last_message do
@@ -173,8 +176,8 @@ defmodule Thrift.Binary.Framed.Client do
           _ ->
             Logger.info("Retrying failed call")
         end
+        {:connect, info, %{s | sock: nil}}
     end
-    {:connect, info, %{s | sock: nil}}
   end
 
   @spec oneway(pid, String.t, data, options) :: :ok

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -316,7 +316,7 @@ defmodule Thrift.Generator.ServiceTest do
 
   thrift_test "clients can be closed", ctx do
     ref = Process.monitor(ctx.client)
-    Client.close(ctx.client)
+    :ok = Client.close(ctx.client)
 
     assert_receive {:DOWN, ^ref, _, _, _}
     refute Process.alive?(ctx.client)

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -315,7 +315,11 @@ defmodule Thrift.Generator.ServiceTest do
   # connection tests
 
   thrift_test "clients can be closed", ctx do
-    :ok = Client.close(ctx.client)
+    ref = Process.monitor(ctx.client)
+    Client.close(ctx.client)
+
+    assert_receive {:DOWN, ^ref, _, _, _}
+    refute Process.alive?(ctx.client)
   end
 
   thrift_test "clients don't retry by default", ctx do
@@ -365,7 +369,6 @@ defmodule Thrift.Generator.ServiceTest do
   thrift_test "clients exit if they try to use a closed client", ctx do
     Process.flag(:trap_exit, true)
 
-    Client.close(ctx.client)
     ref = Process.monitor(ctx.server)
     Process.exit(ctx.server, :normal)
 


### PR DESCRIPTION
Previously, connections would reconnect if they were closed by calling
`Client.close`. This is bad behavior, and could easily lead to running
out of sockets. `Client.close` now closes the TCP connection and stops
the process.