### PR TITLE
Fix up a number of model-related dialyzer warnings

### DIFF
--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -12,6 +12,12 @@ defmodule Thrift.Generator.Service do
     Struct
   }
 
+  # The response struct uses a %Field{} to represent the service function's
+  # return value. Functions can return :void while fields cannot. Until we can
+  # sort out that mismatch, disable dialyzer warnings for those functions.
+  @dialyzer [{:nowarn_function, generate: 2},
+             {:nowarn_function, generate_response_struct: 2}]
+
   def generate(schema, service) do
     file_group = schema.file_group
     dest_module = FileGroup.dest_module(file_group, service)


### PR DESCRIPTION
1. Always refer to models types using their `t` type so we get full
   dialyzer visibility into argument and return values.
2. Many field names are atoms now and shouldn't use String.t.
3. Fix the field list and enum list types, which are lists and not maps.
4. Suppress dialyzer warnings in generator/service.ex due to a mismatch
   between response field types and function return types.