### PR TITLE
Upgrade to dialyxir 0.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule Thrift.Mixfile do
      [{:ex_doc, "~> 0.14", only: :dev},
       {:excoveralls, "~> 0.6", only: [:dev, :test]},
       {:credo, "~> 0.6", only: [:dev, :test]},
-      {:dialyxir, "~> 0.4", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false},
       {:benchfella, "~> 0.3", only: [:dev, :test]},
       {:connection, "~> 1.0"},
       {:ranch, "~> 1.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "dialyxir": {:hex, :dialyxir, "0.4.4", "e93ff4affc5f9e78b70dc7bec7b07da44ae1ed3fef38e7113568dd30ad7b01d3", [:mix], []},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
This is a significant dialyxir release because it now uses the [`:dialyzer`](http://erlang.org/doc/man/dialyzer.html)
module directly instead of spawning a separate VM process in which to
run the dialyzer command line process. More details here:

https://github.com/jeremyjh/dialyxir/wiki/Upgrading-to-0.5

Fortunately for us, we get all of the benefits of this release without
having to make any specific changes to our project configuration.