### PR TITLE
Deterministically merge FileGroup resolutions

### DIFF
--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -102,7 +102,12 @@ defmodule Thrift.Parser.FileGroup do
     end)
     |> Map.new
 
-    resolutions = Map.merge(file_group.resolutions, to_update)
+    # Merge the non-qualified names into the resolution map. We always replace
+    # existing entries with the same key. This produces a predictable result
+    # but is wrong in the sense that it doesn't implement the expected scoping
+    # rules. For example, this still allows a non-qualified name to "leak"
+    # from one included file into another. TODO: revisit resolution scoping
+    resolutions = Map.merge(file_group.resolutions, to_update, fn _k, _v1, v2 -> v2 end)
 
     default_namespace = if file_group.opts[:namespace] do
       %Namespace{:name => :elixir, :path => file_group.opts[:namespace]}


### PR DESCRIPTION
This is an incomplete solution to the fact that our existing resolution
merge was non-deterministic with regard to non-qualified names. We now
always take the newer value for a conflicting key, which gets us closer
to the expected behavior.

We unfortunately still aren't implementing the correct scoping rules.
For example, this still allows a non-qualified name to "leak" from one
included file into another. This should be revisited and addressed with
a more complete solution.