### PR TITLE
Allow the default namespace to be nil

### DIFF
--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -86,6 +86,7 @@ defmodule Thrift.Parser do
   #   - convert an atom to a binary and remove the "Elixir." we get from atoms
   #      like `Foo`
   #   - make sure values are valid module names (CamelCase)
+  defp namespace_string(nil), do: nil
   defp namespace_string(b) when is_binary(b), do: Macro.camelize(b)
   defp namespace_string(a) when is_atom(a) do
     a

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -678,6 +678,9 @@ defmodule Thrift.Parser.ParserTest do
     path = Path.join(@test_file_dir, "get_namespaced.thrift")
     File.write!(path, contents)
 
+    result = parse_file(path, namespace: nil)
+    assert nil == result.ns_mappings.get_namespaced
+
     result = parse_file(path, namespace: "WithNamespace")
     assert "WithNamespace" == result.ns_mappings.get_namespaced.path
 


### PR DESCRIPTION
Change #228 allowed the default namespace to be either an atom or a
string, but we still want to special-case the `nil` atom to mean "no
default namespace". Otherwise, we get a namespace named "Nil".