### PR TITLE
Remove the implicit field identifier warning

### DIFF
--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -159,7 +159,6 @@ FieldList -> '$empty': [].
 FieldList -> Field FieldList: ['$1'|'$2'].
 
 Field -> FieldIdentifier FieldRequired FieldType ident FieldDefault Separator:
-    validate_field(line('$4'), unwrap('$4'), '$1'),
     build_model('Field', line('$4'), ['$1', '$2', '$3', unwrap('$4'), '$5']).
 
 FieldIdentifier -> int ':': unwrap('$1').
@@ -221,8 +220,3 @@ line(_) -> nil.
 % value from a 3-tuple lexer expression.
 unwrap({V, _}) when is_atom(V) -> V;
 unwrap({_,_,V}) -> V.
-
-% Warn when the field identifier isn't explicit.
-validate_field(Line, Name, nil) ->
-    io:format('~p: ~p is missing an explicit field identifier~n', [Line, Name]);
-validate_field(_, _, _) -> ok.

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -288,23 +288,18 @@ defmodule Thrift.Parser.ParserTest do
     }
     """
 
-    warnings = capture_io(fn ->
-      exc = parse(program, [:exceptions, :ApplicationException])
+    exc = parse(program, [:exceptions, :ApplicationException])
 
-      assert exc == %Exception{
-        line: 1,
-        name: :ApplicationException,
-        fields: [
-          %Field{line: 2, id: 1, name: :message, type: :string},
-          %Field{line: 3, id: 2, name: :count, type: :i32, required: true},
-          %Field{line: 4, id: 3, name: :reason, type: :string, required: false},
-          %Field{line: 5, id: -1, name: :other, type: :string, required: false},
-          %Field{line: 6, id: -2, name: :fixed, type: :string, required: false, default: "foo"}
-        ]}
-    end)
-
-    assert warnings =~ ~s("other" is missing an explicit field identifier)
-    assert warnings =~ ~s("fixed" is missing an explicit field identifier)
+    assert exc == %Exception{
+      line: 1,
+      name: :ApplicationException,
+      fields: [
+        %Field{line: 2, id: 1, name: :message, type: :string},
+        %Field{line: 3, id: 2, name: :count, type: :i32, required: true},
+        %Field{line: 4, id: 3, name: :reason, type: :string, required: false},
+        %Field{line: 5, id: -1, name: :other, type: :string, required: false},
+        %Field{line: 6, id: -2, name: :fixed, type: :string, required: false, default: "foo"}
+      ]}
   end
 
   test "an exception with duplicate ids" do
@@ -397,25 +392,18 @@ defmodule Thrift.Parser.ParserTest do
     }
     """
 
-    warnings = capture_io(fn ->
-      s = parse(struct_def, [:structs, :Optionals])
+    s = parse(struct_def, [:structs, :Optionals])
 
-      assert s == %Struct{
-        line: 1,
-        name: :Optionals,
-        fields: [
-          %Field{line: 2, id: -1, name: :name, type: :string, required: :default},
-          %Field{line: 3, id: -2, name: :count, type: :i32, required: :default},
-          %Field{line: 4, id: -3, name: :long_thing, type: :i64, required: :default, default: 12345},
-          %Field{line: 5, id: -4, name: :optional_list, type: {:list, :i32}, required: false}
-        ]
-      }
-    end)
-
-    [:name, :count, :long_thing, :optional_list]
-    |> Enum.each(fn name ->
-      assert warnings =~ ~s("#{name}" is missing an explicit field identifier)
-    end)
+    assert s == %Struct{
+      line: 1,
+      name: :Optionals,
+      fields: [
+        %Field{line: 2, id: -1, name: :name, type: :string, required: :default},
+        %Field{line: 3, id: -2, name: :count, type: :i32, required: :default},
+        %Field{line: 4, id: -3, name: :long_thing, type: :i64, required: :default, default: 12345},
+        %Field{line: 5, id: -4, name: :optional_list, type: {:list, :i32}, required: false}
+      ]
+    }
   end
 
   test "parsing an empty map default value" do


### PR DESCRIPTION
This is useful information, but we don't currently have a good way to
capture it for later display. As is, printing out these warnings as part
of the parsing path can product a bit of spurious output as part of
normal operations because our mix compile task always parses .thrift
files to determine their build targets.