### PR TITLE
Fixed Global resolution

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -56,8 +56,7 @@ defmodule Thrift.Generator do
 
   def generate_to_string!(%FileGroup{} = file_group) do
     Enum.flat_map(file_group.schemas, fn {_, schema} ->
-      schema
-      |> Map.put(:file_group, file_group)
+      %Schema{schema | file_group: file_group}
       |> generate_schema
     end)
     |> Enum.reverse
@@ -68,6 +67,8 @@ defmodule Thrift.Generator do
   end
 
   def generate_schema(schema) do
+    current_module_file_group = FileGroup.set_current_module(schema.file_group, schema.module)
+    schema = %Schema{schema | file_group: current_module_file_group}
     List.flatten([
       generate_enum_modules(schema),
       generate_const_modules(schema),

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -71,9 +71,14 @@ defmodule Thrift.Parser do
     |> FileRef.new
     |> ParsedFile.new
 
+    mod_name = file_path
+    |> Path.basename
+    |> Path.rootname
+    |> String.to_atom
+
     FileGroup.new(file_path, normalized_opts)
     |> FileGroup.add(parsed_file)
-    |> FileGroup.update_resolutions
+    |> FileGroup.set_current_module(mod_name)
   end
 
   # normalize various type permutations that we could get options as

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -370,7 +370,8 @@ defmodule Thrift.Parser.Models do
       includes: [Include.t],
       constants: %{String.t => Literals.t},
       exceptions: %{String.t => Exception.t},
-      typedefs: %{String.t => Types.t}
+      typedefs: %{String.t => Types.t},
+      file_group: FileGroup.t
     }
     defstruct absolute_path: nil,
     module: nil,
@@ -383,7 +384,8 @@ defmodule Thrift.Parser.Models do
     includes: [],
     constants: %{},
     exceptions: %{},
-    typedefs: %{}
+    typedefs: %{},
+    file_group: nil
 
     alias Thrift.Parser.Models.{Constant,
                                 Exception,

--- a/test/thrift/generator/models_test.exs
+++ b/test/thrift/generator/models_test.exs
@@ -165,7 +165,7 @@ defmodule Thrift.Generator.ModelsTest do
   include "shared.thrift"
 
   struct StructWithIncludedNum {
-    1: optional MyInteger num = 5;
+    1: optional shared.MyInteger num = 5;
   }
   """
 
@@ -227,8 +227,8 @@ defmodule Thrift.Generator.ModelsTest do
   include "empty_container.thrift"
   include "nonempty_container.thrift"
 
-  const Cargo ImportantCargo = {"bad_approximations": {1: "zero"}}
-  const Goth TimmyDoesntUnderstandGoth = {"empty_like_my_soul": [1, 2, 3]}
+  const nonempty_container.Cargo ImportantCargo = {"bad_approximations": {1: "zero"}}
+  const empty_container.Goth TimmyDoesntUnderstandGoth = {"empty_like_my_soul": [1, 2, 3]}
   """
 
   thrift_test "constants" do

--- a/test/thrift/parser/resolver_test.exs
+++ b/test/thrift/parser/resolver_test.exs
@@ -212,6 +212,8 @@ defmodule ResolverTest do
       const included.SortType SORT2 = included.SortType.ASC;
       """, as: :file_group, parse: "local.thrift"]) do
 
+      file_group = FileGroup.set_current_module(file_group, :local)
+
       sort1 = FileGroup.resolve(file_group, :"local.SORT1")
       assert %TEnum{name: :"local.SortType"} = FileGroup.resolve(file_group, sort1.type)
       assert 2 == FileGroup.resolve(file_group, sort1.value)
@@ -219,6 +221,9 @@ defmodule ResolverTest do
       sort2 = FileGroup.resolve(file_group, :"local.SORT2")
       assert %TEnum{name: :"included.SortType"} = FileGroup.resolve(file_group, sort2.type)
       assert 110 == FileGroup.resolve(file_group, sort2.value)
+
+      local_sort = FileGroup.resolve(file_group, :SortType)
+      assert %TEnum{name: :"local.SortType", values: [DESC: 1, ASC: 2], line: 2} == local_sort
     end
   end
 end


### PR DESCRIPTION
We had the concept of global resolution, that is, we would place the
current module's definitions in a global scope. This would have worked,
but it wasn't deterministic.

Now, we tell the file group which module is local, and have it update
its resolutions with only the local definitions when we build their
data. This limits the scope of global variables.

In the near future, I intend to move resolution to the Schema. It makes more sense there and we're effectively scoping resolution to schemas now anyways.