### PR TITLE
Use "Thrift.Generated" as the default namespace

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -41,7 +41,9 @@ defmodule Mix.Tasks.Compile.Thrift do
     config      = Keyword.get(Mix.Project.config, :thrift, [])
     input_files = Keyword.get(config, :files, [])
     output_path = Keyword.get(config, :output_path, "lib")
-    parser_opts = Keyword.take(config, [:include_paths, :namespace])
+    parser_opts =
+      Keyword.take(config, [:include_paths, :namespace])
+      |> Keyword.put_new(:namespace, "Thrift.Generated")
 
     mappings =
       input_files

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -27,7 +27,9 @@ defmodule Mix.Tasks.Compile.Thrift do
       search for included files
     * `:namespace` - default namespace for generated modules, which will
       be used when a Thrift file doesn't define its own `elixir` namespace.
-      Defaults to `"Thrift.Generated"`.
+      This value may be given as a string or atom. `nil` indicates that the
+      files should be generated in the `:output_path` root. Defaults to
+      `"Thrift.Generated"`.
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """
@@ -42,7 +44,8 @@ defmodule Mix.Tasks.Compile.Thrift do
     input_files = Keyword.get(config, :files, [])
     output_path = Keyword.get(config, :output_path, "lib")
     parser_opts =
-      Keyword.take(config, [:include_paths, :namespace])
+      config
+      |> Keyword.take([:include_paths, :namespace])
       |> Keyword.put_new(:namespace, "Thrift.Generated")
 
     mappings =

--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -27,6 +27,7 @@ defmodule Mix.Tasks.Compile.Thrift do
       search for included files
     * `:namespace` - default namespace for generated modules, which will
       be used when a Thrift file doesn't define its own `elixir` namespace.
+      Defaults to `"Thrift.Generated"`.
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -29,7 +29,6 @@ defmodule Mix.Tasks.Thrift.Generate do
       search for included files. Defaults to `[]`.
     * `:namespace` - default namespace for generated modules, which will
       be used when Thrift files don't specify their own `elixir` namespace.
-      Defaults to `"Thrift.Generated"`.
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """

--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Thrift.Generate do
       search for included files. Defaults to `[]`.
     * `:namespace` - default namespace for generated modules, which will
       be used when Thrift files don't specify their own `elixir` namespace.
+      Defaults to `"Thrift.Generated"`.
     * `:output_path` - output directory into which the generated Elixir
       source files will be generated. Defaults to `"lib"`.
   """

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -15,7 +15,7 @@ defmodule Thrift.Parser do
   @typedoc "Available parser options"
   @type opt ::
     {:include_paths, [Path.t]} |
-    {:namespace, String.t}
+    {:namespace, module | String.t}
   @type opts :: [opt]
 
   @doc """
@@ -91,12 +91,13 @@ defmodule Thrift.Parser do
   #   - convert an atom to a binary and remove the "Elixir." we get from atoms
   #      like `Foo`
   #   - make sure values are valid module names (CamelCase)
-  defp namespace_string(nil), do: nil
+  defp namespace_string(nil), do: "Thrift.Generated"
+  defp namespace_string(""), do: nil
   defp namespace_string(b) when is_binary(b), do: Macro.camelize(b)
   defp namespace_string(a) when is_atom(a) do
     a
     |> Atom.to_string
-    |> String.replace_leading("Elixir.", "")
+    |> String.trim_leading("Elixir.")
     |> namespace_string
   end
 end

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -91,8 +91,8 @@ defmodule Thrift.Parser do
   #   - convert an atom to a binary and remove the "Elixir." we get from atoms
   #      like `Foo`
   #   - make sure values are valid module names (CamelCase)
-  defp namespace_string(nil), do: "Thrift.Generated"
   defp namespace_string(""), do: nil
+  defp namespace_string(nil), do: nil
   defp namespace_string(b) when is_binary(b), do: Macro.camelize(b)
   defp namespace_string(a) when is_atom(a) do
     a

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -670,12 +670,9 @@ defmodule Thrift.Parser.ParserTest do
       end
     end
 
-    test "is the default (nil)", context do
-      assert "Thrift.Generated" == parse_namespace(context, nil)
-    end
-
-    test "is explicitly empty", context do
+    test "is empty", context do
       assert nil == parse_namespace(context, "")
+      assert nil == parse_namespace(context, nil)
     end
 
     test "is a string", context do

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -656,29 +656,36 @@ defmodule Thrift.Parser.ParserTest do
     end
   end
 
-  test "namespace option can be a string or atom" do
-    contents = """
-    struct GetNamespaced {
-      1: i32 id
-    }
-    """
+  describe "namespace option" do
+    setup do
+      path = Path.join(@test_file_dir, "namespace.thrift")
+      File.write!(path, "struct Struct { 1: i32 id }")
+      {:ok, [path: path]}
+    end
 
-    path = Path.join(@test_file_dir, "get_namespaced.thrift")
-    File.write!(path, contents)
+    defp parse_namespace(context, namespace) do
+      result = parse_file(context[:path], namespace: namespace)
+      if is_map(result.ns_mappings.namespace) do
+        result.ns_mappings.namespace.path
+      end
+    end
 
-    result = parse_file(path, namespace: nil)
-    assert nil == result.ns_mappings.get_namespaced
+    test "is the default (nil)", context do
+      assert "Thrift.Generated" == parse_namespace(context, nil)
+    end
 
-    result = parse_file(path, namespace: "WithNamespace")
-    assert "WithNamespace" == result.ns_mappings.get_namespaced.path
+    test "is explicitly empty", context do
+      assert nil == parse_namespace(context, "")
+    end
 
-    result = parse_file(path, namespace: WithNamespace)
-    assert "WithNamespace" == result.ns_mappings.get_namespaced.path
+    test "is a string", context do
+      assert "WithNamespace" == parse_namespace(context, "WithNamespace")
+      assert "WithNamespace" == parse_namespace(context, "with_namespace")
+    end
 
-    result = parse_file(path, namespace: "with_namespace")
-    assert "WithNamespace" == result.ns_mappings.get_namespaced.path
-
-    result = parse_file(path, namespace: :with_namespace)
-    assert "WithNamespace" == result.ns_mappings.get_namespaced.path
+    test "is an atom", context do
+      assert "WithNamespace" == parse_namespace(context, :WithNamespace)
+      assert "WithNamespace" == parse_namespace(context, :with_namespace)
+    end
   end
 end


### PR DESCRIPTION
Previously, we defaulted to generating our output files in the root, but
that behavior is potentially dangerous because it could class with other
top-level module names.

It's still possible to write files to the root by specifying `""` as the
namespace.

See discussion in #57.