### PR TITLE
Constant modules now reuse suitable existing names

### DIFF
--- a/test/thrift/parser/file_group_test.exs
+++ b/test/thrift/parser/file_group_test.exs
@@ -1,0 +1,18 @@
+defmodule Thrift.Parser.FileGroupTest do
+  use ExUnit.Case
+  use ThriftTestHelpers
+
+  alias Thrift.Parser.FileGroup
+  alias Thrift.Parser.Models.Constant
+
+  test "constant module uses suitable existing name" do
+    with_thrift_files([
+      "myservice.thrift": """
+      const float PI = 3.14
+      service MyService {}
+      """, as: :file_group, parse: "myservice.thrift"]) do
+
+      assert :"Elixir.MyService" == FileGroup.dest_module(file_group, Constant)
+    end
+  end
+end


### PR DESCRIPTION
We were previously writing constants to modules named after their
originating files. This approach was unfortunately too naive because the
resulting module names could conflict with other generated modules that
are spelled the same but different only in letter case.

For example, for a file named `myservice.thrift`:

    const float PI = 3.14
    service MyService {}

We would previously write the constants to `myservice.Myservice`
(`myservice.ex`) and the service definition to `myservice.MyService`
(`my_service.ex`). We now write both to `myservice.MyService` (thanks to
the generator's constants-merging logic) and no longer run into module
name conflicts (see #196).