### PR TITLE
Revise TApplicationException

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -273,21 +273,21 @@ defmodule Thrift.Binary.Framed.Client do
     {:error, {:exception, exception}}
   end
   defp handle_message({:ok, {message_type, seq_id, rpc_name, _}}, seq_id, rpc_name) do
-    exception = %TApplicationException{
-      message: "The server replied with invalid message type #{message_type}",
-      type: :invalid_message_type}
+    exception = TApplicationException.exception(
+      type: :invalid_message_type,
+      message: "The server replied with invalid message type (#{message_type})")
     {:error, {:exception, exception}}
   end
   defp handle_message({:ok, {_, seq_id, mismatched_rpc_name, _}}, seq_id, rpc_name) do
-    exception = %TApplicationException{
-      message: "The server replied to #{mismatched_rpc_name}, but we sent #{rpc_name}",
-      type: :wrong_method_name}
+    exception = TApplicationException.exception(
+      type: :wrong_method_name,
+      message: "The server replied to #{mismatched_rpc_name}, but we sent #{rpc_name}")
     {:error, {:exception, exception}}
   end
   defp handle_message({:ok, {_, mismatched_seq_id, _, _}}, seq_id, _) do
-    exception = %TApplicationException{
-      message: "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{mismatched_seq_id}",
-      type: :bad_sequence_id}
+    exception = TApplicationException.exception(
+      type: :bad_sequence_id,
+      message: "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{mismatched_seq_id}")
     {:error, {:exception, exception}}
   end
   defp handle_message({:error, _} = err, _, _) do

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -68,7 +68,7 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
         message = Protocol.Binary.serialize(:message_begin, {:exception, sequence_id, name})
         serialized_exception = Protocol.Binary.serialize(:application_exception, exc)
 
-        {:error, {:server_error, [message |  serialized_exception]}}
+        {:error, {:server_error, [message | serialized_exception]}}
 
       :noreply ->
         message = Protocol.Binary.serialize(:message_begin, {:reply, sequence_id, name})

--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -4,7 +4,7 @@ defmodule Thrift.TApplicationException do
   """
 
   @enforce_keys [:message, :type]
-  defexception message: "", type: :unknown
+  defexception message: "unknown", type: :unknown
 
   # This list represents the set of well-known TApplicationException types.
   # We primarily use their atom names, but we also need their standardized
@@ -28,7 +28,8 @@ defmodule Thrift.TApplicationException do
 
   def exception(args) when is_list(args) do
     type = Keyword.fetch!(args, :type) |> normalize_type
-    %__MODULE__{message: args[:message] || "", type: type}
+    message = args[:message] || Atom.to_string(type)
+    %__MODULE__{message: message, type: type}
   end
 
   @doc """

--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -4,7 +4,7 @@ defmodule Thrift.TApplicationException do
   """
 
   @enforce_keys [:message, :type]
-  defexception message: nil, type: :unknown
+  defexception message: "", type: :unknown
 
   # This list represents the set of well-known TApplicationException types.
   # We primarily use their atom names, but we also need their standardized
@@ -28,7 +28,7 @@ defmodule Thrift.TApplicationException do
 
   def exception(args) when is_list(args) do
     type = Keyword.fetch!(args, :type) |> normalize_type
-    %__MODULE__{message: args[:message], type: type}
+    %__MODULE__{message: args[:message] || "", type: type}
   end
 
   @doc """

--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -27,7 +27,8 @@ defmodule Thrift.TApplicationException do
   ]
 
   def exception(args) when is_list(args) do
-    %__MODULE__{message: args[:message], type: normalize_type(args[:type])}
+    type = Keyword.fetch!(args, :type) |> normalize_type
+    %__MODULE__{message: args[:message], type: type}
   end
 
   @doc """

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -67,10 +67,9 @@ defmodule Thrift.Generator.Binary.Framed.Server do
             unquote(build_handler_call(file_group, function, response_module))
 
           {_, extra} ->
-            raise Thrift.TApplicationException, [
-              message: "Could not decode #{inspect extra}",
-              type: :protocol_error
-            ]
+            raise Thrift.TApplicationException,
+              type: :protocol_error,
+              message: "Could not decode #{inspect extra}"
         end
       end
     end
@@ -112,9 +111,10 @@ defmodule Thrift.Generator.Binary.Framed.Server do
       catch kind, reason ->
         formatted_exception = Exception.format(kind, reason, System.stacktrace)
         Logger.error("Exception not defined in thrift spec was thrown: #{formatted_exception}")
-        {:server_error, Thrift.TApplicationException.exception(
-          message: "Server error: #{formatted_exception}",
-          type: :internal_error)}
+        error = Thrift.TApplicationException.exception(
+          type: :internal_error,
+          message: "Server error: #{formatted_exception}")
+        {:server_error, error}
       end
     end
   end

--- a/test/thrift/binary/framed/client_test.exs
+++ b/test/thrift/binary/framed/client_test.exs
@@ -2,50 +2,46 @@ defmodule BinaryFramedClientTest do
   use ThriftTestCase
 
   alias Thrift.Binary.Framed.Client
+  alias Thrift.TApplicationException
 
   @thrift_file name: "void_return.thrift", contents: """
   service VoidReturns {
     void my_call(1: i64 id)
   }
   """
-  alias Thrift.TApplicationException, as: TAE
 
   thrift_test "it should be able to deserialize an invalid message" do
     msg = <<128, 1, 0, 2>>
     assert {:error, {:cant_decode_message, ^msg}} = Client.deserialize_message_reply(msg, "my_call", 2757)
   end
 
-  thrift_test "it should be able to read a malformed tapplicationexception" do
+  thrift_test "it should be able to read a malformed TApplicationException" do
     begin = Thrift.Protocol.Binary.serialize(:message_begin, {:exception, 941, "bad"})
     msg = begin <> <<1, 1, 1, 1>>
 
-    expected_message = "Could not decode TApplicationException, remaining was <<1, 1, 1, 1>>"
-    expected_type = :protocol_error
-
     assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "bad", 941)
-    assert %TAE{message: ^expected_message,
-                                         type: ^expected_type} = ex
+    assert %TApplicationException{message: "Unable to decode exception (<<1, 1, 1, 1>>)", type: :protocol_error} = ex
   end
 
   thrift_test "it should be able to deserialize a message with a bad sequence id" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 7, "my_call", 0, 0, 10, 197, 0>>
 
     assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1912)
-    assert %TAE{type: :bad_sequence_id} = ex
+    assert %TApplicationException{type: :bad_sequence_id} = ex
   end
 
   thrift_test "it should be able to deserialize a message with the wrong method name" do
     msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
 
     assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 2757)
-    assert %TAE{type: :wrong_method_name} = ex
+    assert %TApplicationException{type: :wrong_method_name} = ex
   end
 
   thrift_test "it should be able to deserialize a message with the wrong method name and sequence id " do
     msg = <<128, 1, 0, 2, 0, 0, 0, 8, "bad_call", 0, 0, 10, 197, 0>>
 
     assert {:error, {:exception, ex}} = Client.deserialize_message_reply(msg, "my_call", 1234)
-    assert %TAE{type: :bad_sequence_id} = ex
+    assert %TApplicationException{type: :bad_sequence_id} = ex
   end
 
   thrift_test "it should be able to deserialize a void message" do

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -72,7 +72,7 @@ defmodule Servers.Binary.Framed.IntegrationTest do
 
   alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Client
   alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Server
-  alias Thrift.TApplicationException, as: TAE
+  alias Thrift.TApplicationException
 
   def stop_server(server_pid) do
     try do
@@ -137,8 +137,10 @@ defmodule Servers.Binary.Framed.IntegrationTest do
   end
 
   thrift_test "it can handle unexpected exceptions", ctx do
-    assert {:error, {:exception, %TAE{message: msg, type: :internal_error}}} = Client.server_exception(ctx.client)
-    assert String.contains?(msg, "Server error: ** (RuntimeError) This wasn't supposed to happen")
+    {:error, {:exception, %TApplicationException{} = exception}} = Client.server_exception(ctx.client)
+
+    assert :internal_error == exception.type
+    assert exception.message =~ "Server error: ** (RuntimeError) This wasn't supposed to happen"
   end
 
   thrift_test "it can return nothing", ctx do

--- a/test/thrift/exceptions_test.exs
+++ b/test/thrift/exceptions_test.exs
@@ -1,0 +1,47 @@
+defmodule Thrift.ExceptionsTest do
+  use ExUnit.Case, async: true
+
+  describe "TApplicationException" do
+    alias Thrift.TApplicationException
+
+    test "accepts integer type values" do
+      assert %TApplicationException{type: :invalid_protocol} =
+        TApplicationException.exception(type: 9)
+    end
+
+    test "accepts atom type values" do
+      assert %TApplicationException{type: :unknown_method} =
+        TApplicationException.exception(type: :unknown_method)
+    end
+
+    test "defaults to :unknown for unknown integer type values" do
+      assert %TApplicationException{type: :unknown} =
+        TApplicationException.exception(type: 1000)
+    end
+
+    test "raises for unknown atom type values" do
+      assert_raise FunctionClauseError, fn ->
+        TApplicationException.exception(type: :bogus)
+      end
+    end
+
+    test "raises for missing atom type values" do
+      assert_raise FunctionClauseError, fn ->
+        TApplicationException.exception(Keyword.new())
+      end
+    end
+
+    test "accepts a :message argument" do
+      exception = TApplicationException.exception(type: :unknown, message: "Message Text")
+      assert exception.message == "Message Text"
+      assert Exception.message(exception) == "Message Text"
+    end
+
+    test "can convert valid atom type values to integer type values" do
+      assert 9 == TApplicationException.type_id(:invalid_protocol)
+      assert_raise FunctionClauseError, fn ->
+        TApplicationException.type_id(:bogus)
+      end
+    end
+  end
+end

--- a/test/thrift/exceptions_test.exs
+++ b/test/thrift/exceptions_test.exs
@@ -26,7 +26,7 @@ defmodule Thrift.ExceptionsTest do
     end
 
     test "raises for missing atom type values" do
-      assert_raise FunctionClauseError, fn ->
+      assert_raise KeyError, fn ->
         TApplicationException.exception(Keyword.new())
       end
     end

--- a/test/thrift/exceptions_test.exs
+++ b/test/thrift/exceptions_test.exs
@@ -37,6 +37,12 @@ defmodule Thrift.ExceptionsTest do
       assert Exception.message(exception) == "Message Text"
     end
 
+    test "message defaults to the :type string" do
+      exception = TApplicationException.exception(type: :invalid_protocol)
+      assert exception.message == "invalid_protocol"
+      assert Exception.message(exception) == "invalid_protocol"
+    end
+
     test "can convert valid atom type values to integer type values" do
       assert 9 == TApplicationException.type_id(:invalid_protocol)
       assert_raise FunctionClauseError, fn ->

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -221,7 +221,9 @@ defmodule Thrift.Generator.ServiceTest do
     ServerSpy.set_reply(:this_isnt_a_valid_reply)
 
     {:error, {:exception, ex}} = Client.update_username(ctx.client, 1234, "user")
-    assert %TApplicationException{message: "An unknown handler error occurred.", type: :unknown} == ex
+    assert %TApplicationException{
+      message: "An unknown handler error occurred.",
+      type: :unknown} = ex
   end
 
   thrift_test "bang functions return only the value", ctx do


### PR DESCRIPTION
This brings TApplicationException more in line with Elixir's conventions
for creating exceptions. `exception/1` now expects a keyword list with a
:type and an optional :message value. :type can either be an integer or
one of our internal atoms (e.g. :invalid_protocol).

Only the atom form is stored internally. It can be lazily converted back
to an integer at serialization time using `type_id/1`. We don't store
the integer form up-front because it's only used in "exceptional" (ha!)
cases in the server code path.

The list of well-known exception types has been expanded based on the
current Apache Thrift 0.10.0 release (C++ implementation).

Lastly, TApplicationException now has dedicated unit test coverage.