### PR TITLE
Prefer `try do .. after .. end` for cleanup

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -58,10 +58,8 @@ defmodule ThriftTestHelpers do
       unquote(thrift_var) = ThriftTestHelpers.parse(full_path)
       try do
         unquote(block)
+      after
         File.rm_rf!(root_dir)
-      rescue e ->
-        File.rm_rf!(root_dir)
-        raise e
       end
     end
   end


### PR DESCRIPTION
This syntax is shorter, gurantees cleanup, and preserves stacktraces
(unlike re-raising).