### PR TITLE
Address Elixir 1.5 compilation warnings

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -291,7 +291,7 @@ defmodule Thrift.Binary.Framed.Client do
   end
 
   defp to_host(host) when is_bitstring(host) do
-    String.to_char_list(host)
+    String.to_charlist(host)
   end
   defp to_host(host) when is_list(host), do: host
 end

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -24,7 +24,9 @@ defmodule Thrift.Generator.Service do
 
     functions = service.functions |> Map.values
     arg_structs = Enum.map(functions, &generate_args_struct(schema, &1))
-    response_structs = Enum.filter_map(functions, &(!&1.oneway), &generate_response_struct(schema, &1))
+    response_structs = for function <- functions, !function.oneway do
+      generate_response_struct(schema, function)
+    end
 
     framed_client = Generator.Binary.Framed.Client.generate(dest_module, service)
     framed_server = Generator.Binary.Framed.Server.generate(dest_module, service, file_group)
@@ -46,7 +48,7 @@ defmodule Thrift.Generator.Service do
   def generate_args_struct(schema, function) do
     arg_module_name = module_name(function, :args)
 
-    struct = Struct.new(Atom.to_char_list(arg_module_name), function.params)
+    struct = Struct.new(Atom.to_charlist(arg_module_name), function.params)
 
     StructGenerator.generate(:struct, schema, struct.name, struct)
   end
@@ -63,7 +65,7 @@ defmodule Thrift.Generator.Service do
     fields = [success | exceptions]
 
     response_module_name = module_name(function, :response)
-    response_struct = Struct.new(Atom.to_char_list(response_module_name), fields)
+    response_struct = Struct.new(Atom.to_charlist(response_module_name), fields)
 
     StructGenerator.generate(:struct, schema, response_struct.name, response_struct)
   end

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -23,7 +23,7 @@ defmodule Thrift.Parser do
   """
   @spec parse(String.t) :: {:ok, Schema.t} | {:error, term}
   def parse(doc) do
-    doc = String.to_char_list(doc)
+    doc = String.to_charlist(doc)
 
     case :thrift_lexer.string(doc) do
       {:ok, tokens, _} -> :thrift_parser.parse(tokens)

--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -71,7 +71,7 @@ defmodule ThriftTestCase do
         []
       modules ->
         parts = Enum.map(modules, fn({module, _}) -> Module.split(module) end)
-        Enum.filter_map(parts, &alias?(&1, parts), &Module.concat/1)
+        for part <- parts, alias?(part, parts), do: Module.concat(part)
       end
   end
 


### PR DESCRIPTION
 - `to_char_list/1` -> `to_charlist/1`
 - use `for` comprehensions in place of `Enum.filter_map/3`