### PR TITLE
Typedefs in other modules weren't working properly

### DIFF
--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -22,6 +22,10 @@ defmodule Thrift do
   @typedoc "Thrift message types"
   @type message_type :: :call | :reply | :exception | :oneway
 
+  @doc """
+  Returns a list of atoms, each of which is a name of a Thrift primitive type.
+  """
+  @spec primitive_names() :: [Thrift.Parser.Types.Primitive.t]
   def primitive_names do
     [:bool, :i8, :i16, :i32, :i64, :binary, :double, :byte, :string]
   end

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -10,7 +10,7 @@ defmodule Thrift do
 
   @typedoc "Thrift data types"
   @type data_type ::
-    :bool | :byte | :i16 | :i32 | :i64 | :double | :string |
+    :bool | :byte | :i8 | :i16 | :i32 | :i64 | :double | :string | :binary |
     {:map, data_type, data_type} | {:set, data_type} | {:list, data_type}
 
   @type i8   :: (-128..127)
@@ -21,4 +21,8 @@ defmodule Thrift do
 
   @typedoc "Thrift message types"
   @type message_type :: :call | :reply | :exception | :oneway
+
+  def primitive_names do
+    [:bool, :i8, :i16, :i32, :i64, :binary, :double, :byte, :string]
+  end
 end

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -259,6 +259,12 @@ defmodule Thrift.Generator.Utils do
       MapSet.new(unquote(values))
     end
   end
+  def quote_value(set_elements, {:set, type}, schema) do
+    values = Enum.map(set_elements, &quote_value(&1, type, schema))
+    quote do
+      MapSet.new(unquote(values))
+    end
+  end
   def quote_value(list, {:list, type}, schema) when is_list(list) do
     Enum.map(list, &quote_value(&1, type, schema))
   end

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -186,13 +186,15 @@ defmodule Thrift.Parser.FileGroup do
     # (ignoring case), use that instead to avoid generating two modules with
     # the same spellings but different cases.
     schema = file_group.schemas[base]
-    symbols = Enum.map(List.flatten([
+    symbols = [
       Enum.map(schema.enums, fn {_, s} -> s.name end),
       Enum.map(schema.exceptions, fn {_, s} -> s.name end),
       Enum.map(schema.structs, fn {_, s} -> s.name end),
       Enum.map(schema.services, fn {_, s} -> s.name end),
       Enum.map(schema.unions, fn {_, s} -> s.name end)
-    ]), &Atom.to_string/1)
+    ]
+    |> List.flatten
+    |> Enum.map(&Atom.to_string/1)
 
     target = String.downcase(default)
     name = Enum.find(symbols, default, fn s -> String.downcase(s) == target end)

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -194,7 +194,6 @@ defmodule Thrift.Parser.FileGroup do
       Enum.map(schema.unions, fn {_, s} -> s.name end)
     ]), &Atom.to_string/1)
 
-
     target = String.downcase(default)
     name = Enum.find(symbols, default, fn s -> String.downcase(s) == target end)
 

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -124,7 +124,7 @@ defmodule Thrift.Parser.FileGroup do
   end
 
   @spec resolve(t, any) :: any
-  for type <- [:bool, :byte, :i8, :i16, :i32, :i64, :double, :string, :binary] do
+  for type <- Thrift.primitive_names do
     def resolve(_, unquote(type)), do: unquote(type)
   end
   def resolve(%FileGroup{} = group, %Field{type: type} = field) do

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -191,8 +191,9 @@ defmodule Thrift.Parser.FileGroup do
       Enum.map(schema.exceptions, fn {_, s} -> s.name end),
       Enum.map(schema.structs, fn {_, s} -> s.name end),
       Enum.map(schema.services, fn {_, s} -> s.name end),
-      Enum.map(schema.unions, fn {_, s} -> s.name end),
-    ]) |> Enum.map(&Atom.to_string/1)
+      Enum.map(schema.unions, fn {_, s} -> s.name end)
+    ]), &Atom.to_string/1)
+
 
     target = String.downcase(default)
     name = Enum.find(symbols, default, fn s -> String.downcase(s) == target end)

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -136,7 +136,7 @@ defmodule Thrift.Parser.FileGroup do
   def resolve(%FileGroup{resolutions: resolutions} = group, %ValueRef{referenced_value: value_name}) do
     resolve(group, resolutions[value_name])
   end
-  def resolve(%FileGroup{resolutions: resolutions} = group, path) when is_atom(path) do
+  def resolve(%FileGroup{resolutions: resolutions} = group, path) when is_atom(path) and not is_nil(path) do
     # this can resolve local mappings like :Weather or
     # remote mappings like :"common.Weather"
     resolve(group, resolutions[path])

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -565,7 +565,7 @@ defmodule Thrift.Parser.Models do
         canonicalize_defaults(elem_type, elem)
       end
     end
-    defp canonicalize_defaults({:map, {_, _}}, %ValueRef{}=val) do
+    defp canonicalize_defaults({:map, {_, _}}, %ValueRef{} = val) do
       val
     end
     defp canonicalize_defaults({:map, {key_type, val_type}}, defaults) when is_map(defaults) do

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -490,7 +490,7 @@ defmodule Thrift.Parser.Models do
     end
 
     defp merge(schema, {:typedef, actual_type, type_alias}) do
-      %Schema{schema | typedefs: put_new_strict(schema.typedefs, atomify(type_alias), actual_type)}
+      %Schema{schema | typedefs: put_new_strict(schema.typedefs, atomify(type_alias), canonicalize_type(schema, actual_type))}
     end
 
     defp canonicalize_name(%{module: nil}, model) do
@@ -508,6 +508,30 @@ defmodule Thrift.Parser.Models do
         _ ->
           raise "Name collision: #{key}"
       end
+    end
+
+    defp canonicalize_type(schema, %TypeRef{referenced_type: t} = type) do
+      %TypeRef{type | referenced_type: canonicalize_type(schema, t)}
+    end
+    defp canonicalize_type(schema, {:set, elem_type}) do
+      {:set, canonicalize_type(schema, elem_type)}
+    end
+    defp canonicalize_type(schema, {:list, elem_type}) do
+      {:list, canonicalize_type(schema, elem_type)}
+    end
+    defp canonicalize_type(schema, {:map, {key_type, val_type}}) do
+      {:map, {canonicalize_type(schema, key_type), canonicalize_type(schema, val_type)}}
+    end
+    for type <- [:bool, :i8, :i16, :i32, :i64, :binary, :string, :byte] do
+      defp canonicalize_type(_, unquote(type)) do
+        unquote(type)
+      end
+    end
+    defp canonicalize_type(schema, type_name) when is_atom(type_name) do
+      :"#{schema.module}.#{type_name}"
+    end
+    defp canonicalize_name(schema, type_name) when is_bitstring(type_name) do
+      :"#{schema.module}.#{type_name}"
     end
   end
 

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -508,7 +508,6 @@ defmodule Thrift.Parser.Models do
     defp add_namespace_to_name(nil, model) do
       model
     end
-
     defp add_namespace_to_name(module, %{name: name} = model) do
       %{model | name: add_namespace_to_type(module, name)}
     end
@@ -525,7 +524,7 @@ defmodule Thrift.Parser.Models do
     defp add_namespace_to_type(module, {:map, {key_type, val_type}}) do
       {:map, {add_namespace_to_type(module, key_type), add_namespace_to_type(module, val_type)}}
     end
-    for type <- [:bool, :i8, :i16, :i32, :i64, :binary, :string, :byte] do
+    for type <- [:bool, :i8, :i16, :i32, :i64, :double, :binary, :string, :byte] do
       defp add_namespace_to_type(_, unquote(type)) do
         unquote(type)
       end

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -524,7 +524,7 @@ defmodule Thrift.Parser.Models do
     defp add_namespace_to_type(module, {:map, {key_type, val_type}}) do
       {:map, {add_namespace_to_type(module, key_type), add_namespace_to_type(module, val_type)}}
     end
-    for type <- [:bool, :i8, :i16, :i32, :i64, :double, :binary, :string, :byte] do
+    for type <- Thrift.primitive_names do
       defp add_namespace_to_type(_, unquote(type)) do
         unquote(type)
       end

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -530,9 +530,6 @@ defmodule Thrift.Parser.Models do
     defp canonicalize_type(schema, type_name) when is_atom(type_name) do
       :"#{schema.module}.#{type_name}"
     end
-    defp canonicalize_name(schema, type_name) when is_bitstring(type_name) do
-      :"#{schema.module}.#{type_name}"
-    end
   end
 
   @type all :: Namespace.t | Include.t | Constant.t | TEnum.t | Field.t | Exception.t | Struct.t | Union.t | Function.t | Service.t | Schema.t

--- a/lib/thrift/parser/types.ex
+++ b/lib/thrift/parser/types.ex
@@ -3,7 +3,7 @@ defmodule Thrift.Parser.Types do
 
   defmodule Primitive do
     @moduledoc false
-    @type t :: :bool | :i8 | :i16 | :i64 | :binary | :double | :byte | :string
+    @type t :: :bool | :i8 | :i16 | :i32 | :i64 | :binary | :double | :byte | :string
   end
 
   defmodule Ident do

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -673,6 +673,10 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     1: optional additions.ChocolateMapping mapping = {ChocolateAdditionsType.ALMONDS: "almonds",
                                                       ChocolateAdditionsType.NOUGAT: "nougat"}
   }
+
+  struct AlreadyNamespaced {
+    1: optional additions.ChocolateAdditionsType namespaced = additions.ChocolateAdditionsType.ALMONDS
+  }
   """
 
   thrift_test "including a file with typedefs and defaults" do
@@ -685,6 +689,8 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert %ChocoMappings{}.common_name == %{ChocolateAdditionsType.hair => "love"}
     assert %AdditionalMappings{}.mapping == %{ChocolateAdditionsType.almonds => "almonds",
                                               ChocolateAdditionsType.nougat => "nougat"}
+
+    assert %AlreadyNamespaced{}.namespaced == ChocolateAdditionsType.almonds
 
     actual = choco
     |> Chocolate.serialize

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -637,4 +637,26 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert binary == %Byte{val_set: MapSet.new([91])} |> Byte.serialize() |> IO.iodata_to_binary
     assert binary == %Byte{val_set: [91]            } |> Byte.serialize() |> IO.iodata_to_binary
   end
+
+  @thrift_file name: "additions.thrift", contents: """
+  enum ChocolateAdditionsType {
+    ALMONDS = 1,
+    NOUGAT  = 2
+  }
+
+  typedef set<ChocolateAdditionsType> ChocolateAdditions
+  """
+
+  @thrift_file name: "chocolate.thrift", contents: """
+  include "additions.thrift"
+
+  struct Chocolate {
+    1: optional additions.ChocolateAdditions extra_stuff
+  }
+  """
+
+  thrift_test "including a file with typedefs" do
+    serialized = <<14, 0, 1, 8, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0>>
+    assert serialized == %Chocolate{extra_stuff: MapSet.new([1, 2])} |> Chocolate.serialize |> IO.iodata_to_binary
+  end
 end

--- a/test/thrift/parser/annotation_test.exs
+++ b/test/thrift/parser/annotation_test.exs
@@ -28,10 +28,10 @@ defmodule Thrift.Parser.AnnotationTest do
       :"java.final" => "",
       :"annotation.without.value" => "1"}
 
-    assert %Field{name: :bar} = bar = find_field(struct.fields, :bar)
-    assert bar.annotations == %{:presence => "required"}
-    assert %Field{name: :baz} = baz = find_field(struct.fields, :baz)
-    assert baz.annotations == %{:presence => "manual", :"cpp.use_pointer" => ""}
+    assert %Field{name: :bar, annotations: annotations} = find_field(struct.fields, :bar)
+    assert %{:presence => "required"} = annotations
+    assert %Field{name: :baz, annotations: baz_annotations} = find_field(struct.fields, :baz)
+    assert %{:presence => "manual", :"cpp.use_pointer" => ""} = baz_annotations
   end
 
   test "service annotations", context do
@@ -48,7 +48,7 @@ defmodule Thrift.Parser.AnnotationTest do
   test "exception annotations", context do
     assert %{exceptions: %{foo_error: exception}} = context[:schema]
     assert exception.annotations == %{:foo => "bar"}
-    assert %Field{name: :error_code} = field = find_field(exception.fields, :error_code)
-    assert field.annotations == %{:foo => "bar"}
+    assert %Field{name: :error_code, annotations: annotations} = find_field(exception.fields, :error_code)
+    assert %{:foo => "bar"} = annotations
   end
 end

--- a/test/thrift/parser/annotation_test.exs
+++ b/test/thrift/parser/annotation_test.exs
@@ -1,6 +1,7 @@
 defmodule Thrift.Parser.AnnotationTest do
   use ExUnit.Case, async: true
   import Thrift.Parser, only: [parse: 1]
+  alias Thrift.Parser.Models.Field
 
   setup_all do
     {:ok, schema} =
@@ -27,9 +28,9 @@ defmodule Thrift.Parser.AnnotationTest do
       :"java.final" => "",
       :"annotation.without.value" => "1"}
 
-    assert bar = find_field(struct.fields, :bar)
+    assert %Field{name: :bar} = bar = find_field(struct.fields, :bar)
     assert bar.annotations == %{:presence => "required"}
-    assert baz = find_field(struct.fields, :baz)
+    assert %Field{name: :baz} = baz = find_field(struct.fields, :baz)
     assert baz.annotations == %{:presence => "manual", :"cpp.use_pointer" => ""}
   end
 
@@ -47,7 +48,7 @@ defmodule Thrift.Parser.AnnotationTest do
   test "exception annotations", context do
     assert %{exceptions: %{foo_error: exception}} = context[:schema]
     assert exception.annotations == %{:foo => "bar"}
-    assert field = find_field(exception.fields, :error_code)
+    assert %Field{name: :error_code} = field = find_field(exception.fields, :error_code)
     assert field.annotations == %{:foo => "bar"}
   end
 end


### PR DESCRIPTION
Due to the way typedefs work (they're different than everything else),
resolution wasn't working properly on them, this commit adds proper
resolution so you can define them in remote modules.

Fixes #268