### PR TITLE
Check erlang thrift files generated

### DIFF
--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -138,10 +138,10 @@ defmodule ThriftTestCase do
 
     for file <- list_of_files do
       filename = Path.join(reldir, file[:name])
-      System.cmd(System.get_env("THRIFT") || "thrift",
-                 ["-out", outdir,
-                  "--gen", "erl", "-r", filename],
-                 cd: @project_root)
+      {_, 0} = System.cmd(System.get_env("THRIFT") || "thrift",
+                          ["-out", outdir,
+                          "--gen", "erl", "-r", filename],
+                          cd: @project_root)
     end
 
     for source_file <- Path.wildcard("#{erlang_source_dir}/*.erl") do


### PR DESCRIPTION
We should check that the thrift generator is returning a successful exit status to prevent hidden errors generating erlang source files.