### PR TITLE
Delegate response handling to client implementation

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -188,19 +188,50 @@ defmodule Thrift.Binary.Framed.Client do
     :ok
   end
 
-  @spec call(pid, String.t, data, options) :: protocol_response
+  @spec call(pid, String.t, data, module, options) :: protocol_response
   @doc """
   Executes a Thrift RPC. The data argument must be a correctly formatted
   Thrift message.
 
-  The `options` argument takes the same type of keyword list that `start_link` takes.
+  The `opts` argument takes the same type of keyword list that `start_link` takes.
   """
-  def call(conn, rpc_name, serialized_args, opts) do
+  def call(conn, rpc_name, serialized_args, deserialize_module, opts) do
     tcp_opts = Keyword.get(opts, :tcp_opts, [])
     gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
     gen_server_timeout = Keyword.get(gen_server_opts, :timeout, 5000)
 
-    Connection.call(conn, {:call, rpc_name, serialized_args, tcp_opts}, gen_server_timeout)
+    case Connection.call(conn, {:call, rpc_name, serialized_args, tcp_opts}, gen_server_timeout) do
+      {:ok, data} ->
+        deserialize_response(data, deserialize_module)
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp deserialize_response(data, deserialize_module) do
+    case deserialize_module.deserialize(data) do
+      {%{success: nil} = response, ""} ->
+        responses = response
+        |> Map.from_struct
+        |> Map.values
+        |> Enum.reject(&is_nil(&1))
+
+        case responses do
+          [exception] ->
+            {:error, {:exception, exception}}
+
+          [] ->
+            # This case is when we have a void return on the remote RPC.
+            {:ok, nil}
+        end
+
+      {%{success: result}, ""} ->
+        {:ok, result}
+
+      {:error, _} = err ->
+        err
+    end
   end
 
   def handle_call(_, _, %{sock: nil} = s) do

--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -97,30 +97,9 @@ defmodule Thrift.Generator.Binary.Framed.Client do
     end
   end
   defp build_response_handler(%Function{oneway: false}, rpc_name, response_module) do
-    module = Module.concat(response_module, :BinaryProtocol)
-    quote bind_quoted: [module: module, rpc_name: rpc_name] do
-      with {:ok, data} <- ClientImpl.call(client, rpc_name, serialized_args, opts),
-           {%{success: result}, ""} when not is_nil(result) <- module.deserialize(data) do
-        {:ok, result}
-      else
-        {%{success: nil} = reply, ""} ->
-          responses = reply
-          |> Map.from_struct
-          |> Map.values
-          |> Enum.reject(&is_nil(&1))
-
-          case responses do
-            [exception] ->
-              {:error, {:exception, exception}}
-
-            [] ->
-              # This case is when we have a void return on the remote RPC.
-              {:ok, nil}
-          end
-
-        {:error, _} = err ->
-          err
-      end
+    deserialize_module = Module.concat(response_module, :BinaryProtocol)
+    quote bind_quoted: [deserialize_module: deserialize_module, rpc_name: rpc_name] do
+      ClientImpl.call(client, rpc_name, serialized_args, deserialize_module, opts)
     end
   end
 end


### PR DESCRIPTION
This reduces the amount of generated code by doing the bulk of the
response processing in the common client implementation module.

It also highlights an oddity of the way we handle `void` service calls.
Even though those calls are successful, they run through the "error"
path because we don't currently have a way to differentiate between
`nil` (void) and `nil` (missing) "success" field values in the unpacked
response structure. "Reply" messages are only supposed to have either a
"success" field or an exception representation, so we'll need to revisit
our reply implementation before we can improve the success path here.