### PR TITLE
Enable credo for the test/ directory

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,7 +1,7 @@
 %{configs: [
   %{name: "default",
     files: %{
-      included: ["lib/", "src/"],
+      included: ["lib/", "src/", "test/"],
       excluded: [~r"/_build/", ~r"/deps/"]
     },
     requires: [],
@@ -31,7 +31,7 @@
       {Credo.Check.Design.TagFIXME},
 
       {Credo.Check.Readability.FunctionNames},
-      {Credo.Check.Readability.LargeNumbers},
+      {Credo.Check.Readability.LargeNumbers, only_greater_than: 99999},
       {Credo.Check.Readability.MaxLineLength, false},
       {Credo.Check.Readability.ModuleAttributeNames},
       {Credo.Check.Readability.ModuleDoc},

--- a/test/support/lib/parser_utils.ex
+++ b/test/support/lib/parser_utils.ex
@@ -22,7 +22,8 @@ defmodule ParserUtils do
   end
 
   def compile_module(file_group) do
-    Thrift.Generator.generate_to_string!(file_group)
+    file_group
+    |> Thrift.Generator.generate_to_string!
     |> Code.compile_string
   end
 
@@ -159,16 +160,13 @@ defmodule ParserUtils do
   end
 
   def deserialize_to_erlang(binary_data, struct_definition) do
-    try do
-      with({:ok, memory_buffer_transport} <- :thrift_memory_buffer.new(binary_data),
-           {:ok, binary_protocol} <- :thrift_binary_protocol.new(memory_buffer_transport),
-           {_, {:ok, record}} <- :thrift_protocol.read(binary_protocol, struct_definition)) do
-
-        record
-      end
-    rescue _ ->
-        {:error, :cant_decode}
+    with({:ok, memory_buffer_transport} <- :thrift_memory_buffer.new(binary_data),
+          {:ok, binary_protocol} <- :thrift_binary_protocol.new(memory_buffer_transport),
+          {_, {:ok, record}} <- :thrift_protocol.read(binary_protocol, struct_definition)) do
+      record
     end
+  rescue _ ->
+      {:error, :cant_decode}
   end
 
   defp to_erlang_dict(:undefined), do: :undefined

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,9 +11,7 @@ defmodule ThriftTestHelpers do
   end
 
   def build_thrift_file(base_dir, {file_name, contents}) do
-    file_relative_path = file_name
-    |> Atom.to_string
-
+    file_relative_path = Atom.to_string(file_name)
     file_path = Path.join(base_dir, file_relative_path)
 
     file_path
@@ -25,8 +23,7 @@ defmodule ThriftTestHelpers do
   end
 
   def tmp_dir do
-    tmp_path = System.tmp_dir!
-    |> Path.join(Integer.to_string(System.unique_integer))
+    tmp_path = Path.join(System.tmp_dir!, Integer.to_string(System.unique_integer))
 
     File.mkdir(tmp_path)
     tmp_path
@@ -50,11 +47,9 @@ defmodule ThriftTestHelpers do
 
     quote location: :keep do
       root_dir = ThriftTestHelpers.tmp_dir
-      full_path = root_dir
-      |> Path.join(unquote(parsed_file))
+      full_path = Path.join(root_dir, unquote(parsed_file))
 
-      files = unquote(specs)
-      |> Enum.map(&ThriftTestHelpers.build_thrift_file(root_dir, &1))
+      files = Enum.map(unquote(specs), &ThriftTestHelpers.build_thrift_file(root_dir, &1))
       unquote(thrift_var) = ThriftTestHelpers.parse(full_path)
       try do
         unquote(block)

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -70,16 +70,13 @@ defmodule Servers.Binary.Framed.IntegrationTest do
     end
   end
 
-  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Client
-  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Server
+  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.{Client, Server}
   alias Thrift.TApplicationException
 
   def stop_server(server_pid) do
-    try do
-      Server.stop(server_pid)
-    catch :exit, _ ->
-      :ok
-    end
+    Server.stop(server_pid)
+  catch :exit, _ ->
+    :ok
   end
 
   setup_all do

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -5,7 +5,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   alias Thrift.Union.TooManyFieldsSetException
 
   def assert_serializes(%{__struct__: mod} = struct, binary) do
-    assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
+    assert binary == IO.iodata_to_binary(Binary.serialize(:struct, struct))
     assert {^struct, ""} = mod.deserialize(binary)
 
     # If we randomly mutate any byte in the binary, it may deserialize to a
@@ -25,7 +25,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   end
 
   def assert_serializes(%{__struct__: mod} = struct, binary, %{__struct__: mod} = deserialized_struct) do
-    assert binary == Binary.serialize(:struct, struct) |> IO.iodata_to_binary
+    assert binary == IO.iodata_to_binary(Binary.serialize(:struct, struct))
     assert {^deserialized_struct, ""} = mod.deserialize(binary)
   end
 
@@ -629,13 +629,13 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   thrift_test "lists serialize into maps" do
     binary = <<13, 0, 2, 3, 3, 0, 0, 0, 1, 91, 92, 0>>
     assert binary == %Byte{val_map: %{91 => 92}} |> Byte.serialize() |> IO.iodata_to_binary
-    assert binary == %Byte{val_map: [{91, 92}] } |> Byte.serialize() |> IO.iodata_to_binary
+    assert binary == %Byte{val_map: [{91, 92}]} |> Byte.serialize() |> IO.iodata_to_binary
   end
 
   thrift_test "lists serialize into sets" do
     binary = <<14, 0, 3, 3, 0, 0, 0, 1, 91, 0>>
     assert binary == %Byte{val_set: MapSet.new([91])} |> Byte.serialize() |> IO.iodata_to_binary
-    assert binary == %Byte{val_set: [91]            } |> Byte.serialize() |> IO.iodata_to_binary
+    assert binary == %Byte{val_set: [91]} |> Byte.serialize() |> IO.iodata_to_binary
   end
 
   @thrift_file name: "additions.thrift", contents: """

--- a/test/thrift/generator/utils_test.exs
+++ b/test/thrift/generator/utils_test.exs
@@ -3,8 +3,8 @@ defmodule Thrift.Generator.UtilsTest do
   import Thrift.Generator.Utils
 
   defmacro check(input, expected_output) do
-    input_source = optimize_iolist(input) |> Macro.to_string
-    expected_output_source = expected_output |> Macro.to_string
+    input_source = Macro.to_string(optimize_iolist(input))
+    expected_output_source = Macro.to_string(expected_output)
     assert input_source == expected_output_source
   end
 

--- a/test/thrift/parser/lexer_test.exs
+++ b/test/thrift/parser/lexer_test.exs
@@ -93,8 +93,8 @@ defmodule Thrift.Parser.LexerTest do
   test "hex literals" do
     assert tokenize("0x0") == [{:int, 1, 0}]
     assert tokenize("0xff") == [{:int, 1, 255}]
-    assert tokenize("+0xc0c0c0") == [{:int, 1, 12632256}]
-    assert tokenize("-0xc0c0c0") == [{:int, 1, -12632256}]
+    assert tokenize("+0xc0c0c0") == [{:int, 1, 12_632_256}]
+    assert tokenize("-0xc0c0c0") == [{:int, 1, -12_632_256}]
   end
 
   test "double literals" do

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -9,8 +9,8 @@ defmodule BinaryProtocolTest do
     {serializer_mod, serializer_fn} = serializer_mf
     {deserializer_mod, deserializer_fn} = deserializer_mf
 
-    serialized = :erlang.apply(serializer_mod, serializer_fn, [data, :binary])
-    |> IO.iodata_to_binary
+    data = :erlang.apply(serializer_mod, serializer_fn, [data, :binary])
+    serialized = IO.iodata_to_binary(data)
 
     :erlang.apply(deserializer_mod, deserializer_fn, [serialized])
   end
@@ -66,9 +66,9 @@ defmodule BinaryProtocolTest do
 
     assert Erlang.Scalars.new_scalars(sixteen_bits: 12723) == round_trip_struct(%Scalars{sixteen_bits: 12723}, encoder, decoder)
 
-    assert Erlang.Scalars.new_scalars(thirty_two_bits: 1_8362_832) == round_trip_struct(%Scalars{thirty_two_bits: 1_8362_832}, encoder, decoder)
+    assert Erlang.Scalars.new_scalars(thirty_two_bits: 18_362_832) == round_trip_struct(%Scalars{thirty_two_bits: 18_362_832}, encoder, decoder)
 
-    assert Erlang.Scalars.new_scalars(sixty_four_bits: 8872372) == round_trip_struct(%Scalars{sixty_four_bits: 8872372}, encoder, decoder)
+    assert Erlang.Scalars.new_scalars(sixty_four_bits: 8_872_372) == round_trip_struct(%Scalars{sixty_four_bits: 8_872_372}, encoder, decoder)
 
     assert Erlang.Scalars.new_scalars(double_value: 2.37219) == round_trip_struct(%Scalars{double_value: 2.37219}, encoder, decoder)
 
@@ -78,10 +78,7 @@ defmodule BinaryProtocolTest do
   end
 
   thrift_test "it should not encode unset fields" do
-    encoded =  Scalars.serialize(%Scalars{})
-    |> IO.iodata_to_binary
-
-    assert <<0>> == encoded
+    assert <<0>> == IO.iodata_to_binary(Scalars.serialize(%Scalars{}))
   end
 
   @thrift_file name: "containers.thrift", contents: """
@@ -144,7 +141,6 @@ defmodule BinaryProtocolTest do
     #        %Friend{id: 3, username: "dantswain"}
     #       ]}, encoder, decoder)
   end
-
 
   @thrift_file name: "across.thrift", contents: """
     include "containers.thrift"
@@ -304,8 +300,8 @@ defmodule BinaryProtocolTest do
       new_bool: false,
       new_byte: 4,
       new_i16: 102,
-      new_i32: 919482,
-      new_i64: 18281038461,
+      new_i32: 919_482,
+      new_i64: 18_281_038_461,
       new_double: 22.4,
       new_list: [sub],
       new_string: "This is in the sub struct",
@@ -324,7 +320,6 @@ defmodule BinaryProtocolTest do
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
-
 
   # test "nil nested fields get their default value" do
   #   erlang_nested = serialize_nesting_to_erlang(user: user(:elixir, username: "frank"))


### PR DESCRIPTION
This addresses nearly all of the warnings in the test files. It also
tweaks the LargeNumbers rule to only apply to numbers over 99999, which
helps avoid a lot of additional transformations.