### PR TITLE
Upgrade out Docker image to Thrift 0.10.0

### DIFF
--- a/ci/thrift-docker
+++ b/ci/thrift-docker
@@ -1,3 +1,3 @@
 #!/bin/bash
 rootdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-docker run -v ${rootdir}:/thrift-elixir -w /thrift-elixir/${DOCKER_THRIFT_OUT_ROOT} --rm thrift:0.9.3 thrift $*
+docker run -v ${rootdir}:/thrift-elixir -w /thrift-elixir/${DOCKER_THRIFT_OUT_ROOT} --rm thrift:0.10.0 thrift $*


### PR DESCRIPTION
This is only used by Travis CI to power our integration tests.