### PR TITLE
Increase default assert receive timeout

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,4 @@
-ExUnit.configure(exclude: [pending: true])
-ExUnit.start()
+ExUnit.start(exclude: [pending: true], assert_receive_timeout: 500)
 
 defmodule ThriftTestHelpers do
 

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -419,7 +419,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     stop_server(ctx.server)
 
-    assert_receive {:EXIT, _, {:error, :econnrefused}}, 100
+    assert_receive {:EXIT, _, {:error, :econnrefused}}
 
     # this assertion is unusual, as it should exit, but the server
     # doesn't do reads during oneway functions, so it won't get the


### PR DESCRIPTION
CI can be slow so that the default (100ms) is not always enough.

Fixes #235