### PR TITLE
Increase assert_received timeout to 200ms

### DIFF
--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -419,7 +419,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     stop_server(ctx.server)
 
-    assert_receive {:EXIT, _, {:error, :econnrefused}}, 100
+    assert_receive {:EXIT, _, {:error, :econnrefused}}, 200
 
     # this assertion is unusual, as it should exit, but the server
     # doesn't do reads during oneway functions, so it won't get the


### PR DESCRIPTION
We occasionally exceed the 100ms timeout when run within Travis CI's
environment so double the timeout to 200ms to avoid spurious test
failures.

Fixes #235 