### PR TITLE
Handle reserved keywords

### DIFF
--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -41,6 +41,9 @@ defmodule Thrift.Generator.Binary.Framed.Client do
     bang_name = :"#{underscored_name}!"
     options_bang_name = :"#{underscored_options_name}!"
 
+    underscored_name = Macro.pipe(underscored_name, quote do unquote end, 0)
+    bang_name = Macro.pipe(bang_name, quote do unquote end, 0)
+
     vars = Enum.map(function.params, &Macro.var(&1.name, nil))
 
     assignments = function.params

--- a/lib/thrift/generator/enum_generator.ex
+++ b/lib/thrift/generator/enum_generator.ex
@@ -2,9 +2,12 @@ defmodule Thrift.Generator.EnumGenerator do
 
   def generate(name, enum) do
     macro_defs = Enum.map(enum.values, fn {key, value} ->
-      macro_name = to_name(key)
+      macro_name = key
+      |> to_name
+      |> Macro.pipe(quote do unquote end, 0)
+
       quote do
-        defmacro unquote(Macro.var(macro_name, nil)), do: unquote(value)
+        defmacro unquote(macro_name)(), do: unquote(value)
       end
     end)
 

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -35,6 +35,21 @@ KEYWORDS3       = void|bool|byte|i8|i16|i32|i64|double|string|binary|list|map|se
 KEYWORDS4       = const|oneway|extends|throws|service|required|optional
 KEYWORD         = {KEYWORDS1}|{KEYWORDS2}|{KEYWORDS3}|{KEYWORDS4}
 
+RESERVED1       = BEGIN|END|__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__
+RESERVED2       = __METHOD__|__NAMESPACE__|abstract|alias|and|args|as|assert|begin
+RESERVED3       = break|case|catch|class|clone|continue|declare|def|default|del
+RESERVED4       = delete|do|dynamic|elif|else|elseif|elsif|end|enddeclare|endfor
+RESERVED5       = endforeach|endif|endswitch|endwhile|ensure|except|exec|finally
+RESERVED6       = float|for|foreach|from|function|global|goto|if|implements|import
+RESERVED7       = in|inline|instanceof|interface|is|lambda|module|native|new|next
+RESERVED8       = nil|not|or|package|pass|public|print|private|protected|raise|redo
+RESERVED9       = rescue|retry|register|return|self|sizeof|static|super|switch
+RESERVED10      = synchronized|then|this|throw|transient|try|undef|unless|unsigned
+RESERVED11      = until|use|var|virtual|volatile|when|while|with|xor|yield
+RESERVED12      = {RESERVED1}|{RESERVED2}|{RESERVED3}|{RESERVED4}|{RESERVED5}
+RESERVED13      = {RESERVED6}|{RESERVED7}|{RESERVED8}|{RESERVED9}|{RESERVED10}
+RESERVED        = {RESERVED11}|{RESERVED12}|{RESERVED13}
+
 Rules.
 
 {WHITESPACE}    : skip_token.
@@ -49,6 +64,8 @@ __file__        : {token, {file, TokenLine}}.
 {DOUBLE}        : {token, {double, TokenLine, list_to_float(TokenChars)}}.
 {STRING}        : {token, {string, TokenLine, process_string(TokenChars, TokenLen)}}.
 {BOOLEAN}       : {token, {list_to_atom(TokenChars), TokenLine}}.
+
+{RESERVED}      : reserved_keyword_error(TokenChars, TokenLine).
 
 {IDENTIFIER}    : {token, {ident, TokenLine, TokenChars}}.
 
@@ -73,3 +90,9 @@ process_chars([$\\,$t|Chars])   -> [$\t|process_chars(Chars)];
 process_chars([$\\,C|Chars])    -> [C|process_chars(Chars)];
 process_chars([C|Chars])        -> [C|process_chars(Chars)];
 process_chars([])               -> [].
+
+reserved_keyword_error(Keyword, Line) ->
+    Message = io_lib:format(
+      "line ~B: cannot use reserved language keyword \"~s\"", [Line, Keyword]),
+    Exception = 'Elixir.RuntimeError':exception(list_to_binary(Message)),
+    erlang:error(Exception).

--- a/test/mix/tasks/thrift.generate_test.exs
+++ b/test/mix/tasks/thrift.generate_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Thrift.GenerateTest do
 
   test "specifying an invalid Thrift file" do
     in_fixture fn ->
-      assert_raise Mix.Error, ~r/Error parsing/, fn ->
+      assert_raise Mix.Error, ~r/reserved language keyword/, fn ->
         run([__ENV__.file])
       end
     end

--- a/test/thrift/generator/models_test.exs
+++ b/test/thrift/generator/models_test.exs
@@ -8,6 +8,9 @@ defmodule Thrift.Generator.ModelsTest do
     BANNED = 6,
     EVIL = 0x20,
   }
+  enum Operator {
+    AND = 0,
+  }
   struct StructWithEnum {
     1: Status status_field,
     12: Status status_field_with_default = Status.INACTIVE,
@@ -72,6 +75,18 @@ defmodule Thrift.Generator.ModelsTest do
     assert struct.status_map == nil
     assert struct.status_set == nil
     assert struct.status_list == nil
+  end
+
+  thrift_test "generated enums that conflict with Elixir keywords" do
+    assert Operator.and == 0
+    assert Operator.member?(0) == true
+    assert Operator.name?(:and) == true
+    assert Operator.value_to_name(0) == {:ok, :and}
+    assert Operator.value_to_name!(0) == :and
+    assert Operator.name_to_value(:and) == {:ok, 0}
+    assert Operator.name_to_value!(:and) == 0
+    assert Operator.meta(:names) == [:and]
+    assert Operator.meta(:values) == [0]
   end
 
   @thrift_file name: "exceptions.thrift", contents: """

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -25,6 +25,7 @@ defmodule Thrift.Generator.ServiceTest do
     list<i64> friend_ids_of(1: i64 user_id),
     map<string, i64> friend_nicknames(1: i64 user_id),
     set<string> tags(1: i64 user_id),
+    bool And(1: bool left, 2: bool right),
   }
   """
 
@@ -292,6 +293,13 @@ defmodule Thrift.Generator.ServiceTest do
 
     expected = MapSet.new(["sports", "debate", "motorcycles"])
     assert {:ok, expected} == Client.tags(ctx.client, 91_281)
+  end
+
+  thrift_test "it handles method names that conflict with Elixir keywords", ctx do
+    ServerSpy.set_reply(true)
+
+    expected = true
+    assert {:ok, expected} == Client.and(ctx.client, true, true)
   end
 
   thrift_test "it has a configurable gen_server timeout", ctx do

--- a/test/thrift/parser/file_group_test.exs
+++ b/test/thrift/parser/file_group_test.exs
@@ -8,7 +8,7 @@ defmodule Thrift.Parser.FileGroupTest do
   test "constant module uses suitable existing name" do
     with_thrift_files([
       "myservice.thrift": """
-      const float PI = 3.14
+      const double PI = 3.14
       service MyService {}
       """, as: :file_group, parse: "myservice.thrift"]) do
 

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -648,6 +648,29 @@ defmodule Thrift.Parser.ParserTest do
     end
   end
 
+  test "names cannot override built-in keywords" do
+    thrift = """
+    struct continue {}
+    """
+
+    expected_error = "line 1: cannot use reserved language keyword \"continue\""
+    assert_raise RuntimeError, expected_error, fn ->
+      parse(thrift) |> IO.inspect
+    end
+  end
+
+  test "names can be reserved keywords if they have a difference case" do
+    continue_struct = parse("""
+    struct Continue {}
+    """, [:structs, :Continue])
+
+    assert continue_struct == %Struct{
+      line: 1,
+      name: :Continue,
+      fields: []
+    }
+  end
+
   describe "namespace option" do
     setup do
       path = Path.join(@test_file_dir, "namespace.thrift")

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -659,7 +659,7 @@ defmodule Thrift.Parser.ParserTest do
     end
   end
 
-  test "names can be reserved keywords if they have a difference case" do
+  test "names can be reserved keywords if they have a different case" do
     continue_struct = parse("""
     struct Continue {}
     """, [:structs, :Continue])

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -655,7 +655,7 @@ defmodule Thrift.Parser.ParserTest do
 
     expected_error = "line 1: cannot use reserved language keyword \"continue\""
     assert_raise RuntimeError, expected_error, fn ->
-      parse(thrift) |> IO.inspect
+      parse(thrift)
     end
   end
 


### PR DESCRIPTION
[Similarly to apache/thrift](https://github.com/apache/thrift/blob/19baeefd8c38d62085891d7956349601f79448b3/compiler/cpp/src/thrift/thriftl.ll#L273), we disallow keywords being used in the Thrift IDL.

However the keywords restriction only applies to exact-casing, so for example we must support "AND" as a valid enum. When down-casing this value, it conflicts with the Elixir keyword "and", and so using some macro magic we can get around this limitation.

Additionally, since we down-case method names too, similar logic applies when generating a client. The server implementation did not require any changes.

Fixes: #294