### PR TITLE
Support multiple destination module name casings

### DIFF
--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -213,14 +213,13 @@ defmodule Thrift.Parser.FileGroup do
 
     case file_group.ns_mappings[module_name] do
       nil ->
-        Module.concat(List.flatten([Elixir, struct_name]))
+        Module.concat([struct_name])
       namespace = %Namespace{} ->
-        namespace_module = namespace.path
-        |> String.split(".")
-        |> Enum.map(&Macro.camelize/1)
-        |> Enum.join(".")
-        |> String.to_atom
-        Module.concat(List.flatten([namespace_module, struct_name]))
+        namespace_parts =
+          namespace.path
+          |> String.split(".")
+          |> Enum.map(&Macro.camelize/1)
+        Module.concat(namespace_parts ++ [struct_name])
     end
   end
 

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -203,12 +203,15 @@ defmodule Thrift.Parser.FileGroup do
   end
 
   def dest_module(file_group, name) do
-    [thrift_module | struct_name] = name
-    |> Atom.to_string
-    |> String.split(".")
-    |> Enum.map(&String.to_atom/1)
+    name_parts =
+      name
+      |> Atom.to_string
+      |> String.split(".", parts: 2)
 
-    case file_group.ns_mappings[thrift_module] do
+    module_name = name_parts |> Enum.at(0) |> String.to_atom
+    struct_name = name_parts |> Enum.at(1) |> initialcase
+
+    case file_group.ns_mappings[module_name] do
       nil ->
         Module.concat(List.flatten([Elixir, struct_name]))
       namespace = %Namespace{} ->
@@ -219,6 +222,14 @@ defmodule Thrift.Parser.FileGroup do
         |> String.to_atom
         Module.concat(List.flatten([namespace_module, struct_name]))
     end
+  end
+
+  # Capitalize just the initial character of a string, leaving the rest of the
+  # string's characters intact.
+  @spec initialcase(String.t) :: String.t
+  defp initialcase(string) when is_binary(string) do
+    {char, rest} = String.Casing.titlecase_once(string)
+    char <> rest
   end
 
   # check if the given model is defined in the root file of the file group

--- a/test/thrift/parser/file_group_test.exs
+++ b/test/thrift/parser/file_group_test.exs
@@ -15,4 +15,11 @@ defmodule Thrift.Parser.FileGroupTest do
       assert :"Elixir.MyService" == FileGroup.dest_module(file_group, Constant)
     end
   end
+
+  test "destination module supports input names in various casings" do
+    file_group = FileGroup.new("casing.thrift")
+    assert :"Elixir.UPPERCASE" == FileGroup.dest_module(file_group, :"module.UPPERCASE")
+    assert :"Elixir.Lowercase" == FileGroup.dest_module(file_group, :"module.lowercase")
+    assert :"Elixir.CamelCase" == FileGroup.dest_module(file_group, :"module.CamelCase")
+  end
 end


### PR DESCRIPTION
Previously, we expected the "struct name" portion of the input name to
be a suitable module name string (for Module.concat/1). Lowercased names
failed this assumption because they're not valid aliases.

This change reworks the destination module name processing to ensure
that the "struct name" string starts with an initial capitalize letter.

Fixes #297