### PR TITLE
Remove the client-side retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ Name             | Type | Description
 -----------------|------|---------------
 `:timeout`       | positive integer | The default timeout for reading from, writing to, and connecting to sockets.
 `send_timeout`   | positive integer | The amount of time in milliseconds to wait before sending data fails.
-`retry` | boolean | Whether or not to retry if the server closes the connection (default false). If the client detects that the server has closed the connection, the last message will be retried. This is helpful when using the client in IEx, or in a situation where the client won't be used for a while, but can result in duplicate messages being sent to the server. Due to the subtleties of `gen_tcp`, oneway messages are not retried.
 
 ##### GenServer Opts
 Name             | Type | Description
@@ -189,11 +188,10 @@ Name             | Type | Description
 ```elixir
 alias Thrift.Test.UserService.Binary.Framed.Client
 {:ok, client} = Client.start_link("localhost", 2345,
-                tcp_opts: [retry: true], gen_server_opts: [timeout: 10_000])
+                tcp_opts: [], gen_server_opts: [timeout: 10_000])
 
 ```
-In the above example, the client will retry once if the remote server severs the connection.
-These options also set the GenServer timeout to be ten seconds, which means the remote
+These options set the GenServer timeout to be ten seconds, which means the remote
 side can take its time to reply.
 
 

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -118,7 +118,7 @@ defmodule Thrift.Binary.Framed.Client do
   end
 
   @doc false
-  def disconnect(info, %{sock: sock} = s) do
+  def disconnect(info, %{sock: sock}) do
     :ok = :gen_tcp.close(sock)
 
     case info do
@@ -126,14 +126,14 @@ defmodule Thrift.Binary.Framed.Client do
         Connection.reply(from, :ok)
         {:stop, :normal, nil}
 
-      {:error, :closed} ->
+      {:error, :closed} = error ->
         Logger.error("Connection closed")
-        {:connect, info, %{s | sock: nil}}
+        {:stop, error, nil}
 
-      {:error, reason} ->
+      {:error, reason} = error ->
         reason = :inet.format_error(reason)
         Logger.error("Connection error: #{reason}")
-        {:connect, info, %{s | sock: nil}}
+        {:stop, error, nil}
     end
   end
 

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -390,7 +390,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     client = ctx.client
     assert_receive {:DOWN, ^ref, _, _, _}
-    assert_receive {:EXIT, ^client, {:error, :econnrefused}}
+    assert_receive {:EXIT, ^client, {:error, :closed}}
   end
 
   thrift_test "it returns :ok on void oneway functions if the server dies", ctx do

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -343,7 +343,7 @@ defmodule Thrift.Generator.ServiceTest do
     refute Process.alive?(ctx.client)
   end
 
-  thrift_test "clients don't retry by default" do
+  thrift_test "clients exit on connection timeout" do
     Process.flag(:trap_exit, true)
 
     new_server_port = random_port()
@@ -359,41 +359,13 @@ defmodule Thrift.Generator.ServiceTest do
     end
   end
 
-  thrift_test "clients retry when making an RPC on a closed server when retry is true" do
-    new_server_port = random_port()
-    {:ok, server} = start_server(new_server_port, 20)
-    {:ok, client} = Client.start_link("127.0.0.1", new_server_port, [tcp_opts: [retry: true]])
-
-    :timer.sleep(50)
-
-    ServerSpy.set_reply([9, 8, 7, 6])
-
-    assert {:ok, [9, 8, 7, 6]} = Client.friend_ids_of(client, 1234)
-    on_exit fn ->
-      stop_server(server)
-    end
-  end
-
-  thrift_test "clients retry when making a oneway call on a closed server when retry is true" do
-    new_server_port = random_port()
-    {:ok, server} = start_server(new_server_port, 20)
-    {:ok, client} = Client.start_link("127.0.0.1", new_server_port, [tcp_opts: [retry: true]])
-    :timer.sleep(50)
-
-    assert {:ok, nil} = Client.do_some_work(client, "Do the work!")
-
-    on_exit fn ->
-      stop_server(server)
-    end
-  end
-
   thrift_test "clients exit if they try to use a closed client", ctx do
     Process.flag(:trap_exit, true)
     stop_server(ctx.server)
     assert {{:error, :econnrefused}, _} = catch_exit(Client.friend_ids_of(ctx.client, 1234))
   end
 
-  thrift_test "clients retry if the server dies handling a message", ctx do
+  thrift_test "clients exit if the server dies handling a message", ctx do
     ref = Process.monitor(ctx.server)
 
     ServerSpy.set_reply({:sleep, 5000, 1234})


### PR DESCRIPTION
In addition to the moderate state-management complexity introduced by
this feature, we've also found that implementing message-level retry
logic directly within a Thrift client to not be ideal. Instead, retries
are better implemented by either application logic (which has complete
understanding of the message payloads, idempotency, etc.) or closer to
the wire level, which can make stronger guarantees about whether the
original message was or was not delivered.

See #261 