### PR TITLE
Stop special-casing the {:error, :closed} case

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -206,9 +206,6 @@ defmodule Thrift.Binary.Framed.Client do
       {:error, :timeout} = timeout ->
         {:reply, timeout, s}
 
-      {:error, :closed} = error ->
-        {:disconnect, error, s}
-
       {:error, _} = error ->
         {:disconnect, error, error, s}
     end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -350,9 +350,10 @@ defmodule Thrift.Generator.ServiceTest do
     {:ok, new_server} = start_server(new_server_port, 20)
 
     {:ok, client} = Client.start_link("127.0.0.1", new_server_port, [])
-
     :timer.sleep(50) # sleep beyond the server's recv_timeout
-    assert catch_exit(Client.friend_ids_of(client, 1234))
+
+    assert Client.friend_ids_of(client, 1234) == {:error, :closed}
+    assert_receive {:EXIT, ^client, {:error, :closed}}
 
     on_exit fn ->
       stop_server(new_server)


### PR DESCRIPTION
We can instead reply immediately (with the existing :disconnect case)
and let the client send the :EXIT.

See #261, #303.