### PR TITLE
Use any free port for our test server process

### DIFF
--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -92,10 +92,11 @@ defmodule Thrift.Generator.ServiceTest do
       handler: ServerSpy,
       socket_opts: [recv_timeout: recv_timeout],
       framed: true]
-    with {:ok, pid} <- :thrift_socket_server.start(opts),
-         port <- GenServer.call(pid, {:get, :port}) do
-      {:ok, pid, port}
-    else
+
+    case :thrift_socket_server.start(opts) do
+      {:ok, pid} ->
+        port = GenServer.call(pid, {:get, :port})
+        {:ok, pid, port}
       error ->
         error
     end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -85,13 +85,20 @@ defmodule Thrift.Generator.ServiceTest do
   alias Thrift.Generator.ServiceTest.SimpleService.Binary.Framed.Client
   alias Thrift.Generator.ServiceTest.UsernameTakenException
 
-  defp start_server(port, recv_timeout \\ :infinity) do
-    :thrift_socket_server.start(
-      handler: ServerSpy,
-      port: port,
-      framed: true,
+  defp start_server(recv_timeout \\ :infinity) do
+    opts = [
+      port: 0,
       service: :simple_service_thrift,
-      socket_opts: [recv_timeout: recv_timeout])
+      handler: ServerSpy,
+      socket_opts: [recv_timeout: recv_timeout],
+      framed: true]
+    with {:ok, pid} <- :thrift_socket_server.start(opts),
+         port <- GenServer.call(pid, {:get, :port}) do
+      {:ok, pid, port}
+    else
+      error ->
+        error
+    end
   end
 
   defp stop_server(server_pid) when is_pid(server_pid) do
@@ -105,14 +112,8 @@ defmodule Thrift.Generator.ServiceTest do
     assert_receive {:DOWN, ^ref, _, _, _}
   end
 
-  defp random_port do
-    :erlang.unique_integer([:positive, :monotonic]) + 10_000
-  end
-
   setup do
-    port = random_port()
-
-    {:ok, server} = start_server(port)
+    {:ok, server, port} = start_server()
     {:ok, client} = Client.start_link('127.0.0.1', port,
                                             [tcp_opts: [timeout: 5000]])
     {:ok, handler_pid} = ServerSpy.start_link
@@ -346,9 +347,7 @@ defmodule Thrift.Generator.ServiceTest do
   thrift_test "clients exit on connection timeout" do
     Process.flag(:trap_exit, true)
 
-    new_server_port = random_port()
-    {:ok, new_server} = start_server(new_server_port, 20)
-
+    {:ok, new_server, new_server_port} = start_server(20)
     {:ok, client} = Client.start_link("127.0.0.1", new_server_port, [])
     :timer.sleep(50) # sleep beyond the server's recv_timeout
 


### PR DESCRIPTION
Passing 0 as the port tells the TCP subsystem to select any free port,
and we can querying the server's listening port via a {:get, :port}
call.

This lets us drop the random_port() helper function and makes things
simpler overall.