### PR TITLE
Remove with _with_options function variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,8 @@ four functions.
 
 Function name  | Description
 ---------------|----------
-`get_user_by_id/2` | Makes a request to the remote `get_user_by_id` RPC. Returns `{:ok, response}` or `{:error, reason}` tuples.
-`get_user_by_id!/2`  | Same as above, but raises an exception if something goes wrong. The type of exception can be one of the exceptions defined in the service or `Thrift.TApplicationException`.
-`get_user_by_id_with_options/3` | Allows you to pass `gen_tcp` and `GenServer` options to your client. This is useful for setting the `GenServer` timeout if you expect your RPC to take longer than the default of 5 seconds. Like `get_user_by_id/2`, this function returns `{:ok, response}` or `{:error, reason}` tuples.
-`get_user_by_id_with_options!/3` | Allows you to pass `gen_tcp` and `GenServer` options and raises an exception if an error occurs.
+`get_user_by_id/3` | Makes a request to the remote `get_user_by_id` RPC. You can optionally pass `gen_tcp` and `GenServer` options (such as a timeout) to the client as the final `rpc_opts` argument. Returns `{:ok, response}` or `{:error, reason}` tuples.
+`get_user_by_id!/3`  | Same as above, but raises an exception if something goes wrong. The type of exception can be one of the exceptions defined in the service or `Thrift.TApplicationException`.
 
 **Note:** in the above example, the function `deleteUser` will be converted to `delete_user` to comply with Elixir's [naming conventions](http://elixir-lang.org/docs/stable/elixir/naming-conventions.html).
 

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -308,7 +308,7 @@ defmodule Thrift.Generator.ServiceTest do
     ServerSpy.set_reply({:sleep, 1000, [1, 3, 4]})
 
     assert catch_exit(
-      Client.friend_ids_of_with_options(ctx.client, 1234, [gen_server_opts: [timeout: 200]])
+      Client.friend_ids_of(ctx.client, 1234, [gen_server_opts: [timeout: 200]])
     )
   end
 
@@ -317,26 +317,9 @@ defmodule Thrift.Generator.ServiceTest do
     ServerSpy.set_reply({:sleep, 1000, [1, 3, 4]})
 
     assert ExUnit.CaptureLog.capture_log(fn ->
-      assert {:error, :timeout} = Client.friend_ids_of_with_options(client, 12_914, [tcp_opts: [timeout: 1]])
+      assert {:error, :timeout} = Client.friend_ids_of(client, 12_914, [tcp_opts: [timeout: 1]])
       assert_receive {:EXIT, ^client, {:error, :timeout}}
     end) =~ "1ms"
-  end
-
-  thrift_test "oneway functions should not have an options version" do
-    refute {:do_some_work_with_options, 3} in Client.__info__(:functions)
-  end
-
-  thrift_test "functions that return values have an options version" do
-    defined_functions = Client.__info__(:functions)
-
-    assert {:ping_with_options, 2}              in defined_functions
-    assert {:update_username_with_options, 4}   in defined_functions
-    assert {:get_by_id_with_options, 3}         in defined_functions
-    assert {:are_friends_with_options, 4}       in defined_functions
-    assert {:mark_inactive_with_options, 3}     in defined_functions
-    assert {:friend_ids_of_with_options, 3}     in defined_functions
-    assert {:friend_nicknames_with_options, 3}  in defined_functions
-    assert {:tags_with_options, 3}              in defined_functions
   end
 
   # connection tests


### PR DESCRIPTION
These were introduced to avoid potential conflicts between our options
parameter (named `opts`) and an `opts` function paramter named by the
Thrift IDL.

This resulted in doubling the number of generated methods (as well as
another level of function call indirection), in addition to making the
resulting user-callable API a little bit more complex.

Instead, go back to using just two generated functions (the "regular"
call and the "bang!" exception-raising variant) and rename our options
parameter to `rpc_opts`, which is very unlikely to conflict in practice.