### PR TITLE
Further simplify the generated client code

### DIFF
--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -28,7 +28,7 @@ defmodule Thrift.Generator.Service do
       generate_response_struct(schema, function)
     end
 
-    framed_client = Generator.Binary.Framed.Client.generate(dest_module, service)
+    framed_client = Generator.Binary.Framed.Client.generate(service)
     framed_server = Generator.Binary.Framed.Server.generate(dest_module, service, file_group)
 
     service_module = quote do


### PR DESCRIPTION
- We don't need the fullly-qualified service module because we're
  already generating code within it. This improves readability and
  cuts down on the overall size of the generated source file.
- Just use `unquote/1` in the response handler macros to reduce the
  amount of generated code that was being produced by `bind_quoted`.
  
  