### PR TITLE
Improve the oneway function client-server test

### DIFF
--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -385,14 +385,14 @@ defmodule Thrift.Generator.ServiceTest do
     Process.flag(:trap_exit, true)
     ServerSpy.set_reply(:noreply)
 
+    :sys.get_state(client)
     stop_server(server)
-    assert_received {:EXIT, ^server, :normal}
 
     # this assertion is unusual, as it should exit, but the server
     # doesn't do reads during oneway functions, so it won't get the
     # error that the other side has been closed.
     # see: http://erlang.org/pipermail/erlang-questions/2014-April/078545.html
     {:ok, nil} = Client.do_some_work(client, "work!")
-    assert_receive {:EXIT, ^client, {:error, :econnrefused}}
+    assert_receive {:EXIT, ^client, {:error, :closed}}
   end
 end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -393,6 +393,5 @@ defmodule Thrift.Generator.ServiceTest do
     # error that the other side has been closed.
     # see: http://erlang.org/pipermail/erlang-questions/2014-April/078545.html
     {:ok, nil} = Client.do_some_work(client, "work!")
-    assert_receive {:EXIT, ^client, {:error, :closed}}
   end
 end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -381,18 +381,18 @@ defmodule Thrift.Generator.ServiceTest do
     assert_receive {:EXIT, ^client, {:error, :closed}}
   end
 
-  thrift_test "it returns :ok on void oneway functions if the server dies", ctx do
+  thrift_test "oneway functions return :ok if the server dies", %{client: client, server: server} do
     Process.flag(:trap_exit, true)
     ServerSpy.set_reply(:noreply)
 
-    stop_server(ctx.server)
-
-    assert_receive {:EXIT, _, {:error, :econnrefused}}, 100
+    stop_server(server)
+    assert_received {:EXIT, ^server, :normal}
 
     # this assertion is unusual, as it should exit, but the server
     # doesn't do reads during oneway functions, so it won't get the
     # error that the other side has been closed.
     # see: http://erlang.org/pipermail/erlang-questions/2014-April/078545.html
-    {:ok, nil} = Client.do_some_work(ctx.client, "work!")
+    {:ok, nil} = Client.do_some_work(client, "work!")
+    assert_receive {:EXIT, ^client, {:error, :econnrefused}}
   end
 end


### PR DESCRIPTION
This test has been flaky because it relies on race conditions.

Force synchronization using `:sys.get_state/1` and remove
assertions that can't be guaranteed.
  