### PR TITLE
Use atoms to represent enums

### DIFF
--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -582,16 +582,16 @@ defmodule Thrift.Generator.BinaryProtocolTest do
 
   thrift_test "constants and structs defined in the same file" do
     assert %XMan{
-      handle: "Wolverine", name: "Logan", power_level: PowerLevel.beta, universe: XMan.earth_616
+      handle: "Wolverine", name: "Logan", power_level: :BETA, universe: XMan.earth_616
     } == XMan.wolverine
     assert %XMan{
-      handle: "Cyclops", name: "Scott Summers", power_level: PowerLevel.beta, universe: XMan.earth_616
+      handle: "Cyclops", name: "Scott Summers", power_level: :BETA, universe: XMan.earth_616
     } == XMan.cyclops
     assert %XMan{
-      handle: "Storm", name: "Ororo Monroe", power_level: PowerLevel.alpha, universe: XMan.earth_616
+      handle: "Storm", name: "Ororo Monroe", power_level: :ALPHA, universe: XMan.earth_616
     } == XMan.storm
     assert %XMan{
-      handle: "Phoenix", name: "Jean Grey", power_level: PowerLevel.omega, universe: XMan.earth_616
+      handle: "Phoenix", name: "Jean Grey", power_level: :OMEGA, universe: XMan.earth_616
     } == XMan.phoenix
   end
 
@@ -680,17 +680,17 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   """
 
   thrift_test "including a file with typedefs and defaults" do
-    choco = %Chocolate{extra_stuff: MapSet.new([1, 2])}
+    choco = %Chocolate{extra_stuff: MapSet.new([:ALMONDS, :NOUGAT])}
 
-    assert choco.secret_ingredient == ChocolateAdditionsType.hair
+    assert choco.secret_ingredient == :HAIR
 
-    assert %Allergies{}.may_contain == [ChocolateAdditionsType.almonds]
-    assert %OddSnackIngredients{}.other_things == MapSet.new([ChocolateAdditionsType.nougat])
-    assert %ChocoMappings{}.common_name == %{ChocolateAdditionsType.hair => "love"}
-    assert %AdditionalMappings{}.mapping == %{ChocolateAdditionsType.almonds => "almonds",
-                                              ChocolateAdditionsType.nougat => "nougat"}
+    assert %Allergies{}.may_contain == [:ALMONDS]
+    assert %OddSnackIngredients{}.other_things == MapSet.new([:NOUGAT])
+    assert %ChocoMappings{}.common_name == %{:HAIR => "love"}
+    assert %AdditionalMappings{}.mapping == %{:ALMONDS => "almonds",
+                                              :NOUGAT => "nougat"}
 
-    assert %AlreadyNamespaced{}.namespaced == ChocolateAdditionsType.almonds
+    assert %AlreadyNamespaced{}.namespaced == :ALMONDS
 
     actual = choco
     |> Chocolate.serialize

--- a/test/thrift/generator/models_test.exs
+++ b/test/thrift/generator/models_test.exs
@@ -21,71 +21,60 @@ defmodule Thrift.Generator.ModelsTest do
   """
 
   thrift_test "generating enum" do
-    assert Status.active == 1
-    assert Status.inactive == 2
-    assert Status.banned == 6
-    assert Status.evil == 32
+    assert Status.active == :ACTIVE
+    assert Status.inactive == :INACTIVE
+    assert Status.banned == :BANNED
+    assert Status.evil == :EVIL
 
-    assert Status.member?(0) == false
-    assert Status.member?(1) == true
-    assert Status.member?(2) == true
-    assert Status.member?(3) == false
-    assert Status.member?(4) == false
-    assert Status.member?(5) == false
-    assert Status.member?(6) == true
-    assert Status.member?(7) == false
+    assert Status.member?(:ACTIVE) == true
+    assert Status.member?(:INACTIVE) == true
+    assert Status.member?(:BANNED) == true
+    assert Status.member?(:EVIL) == true
+    assert Status.member?(:BAMBOOZLED) == false
 
-    assert Status.name?(:active) == true
-    assert Status.name?(:inactive) == true
-    assert Status.name?(:banned) == true
-    assert Status.name?(:evil) == true
-    assert Status.name?(:bamboozled) == false
-
-    assert Status.value_to_name(1) == {:ok, :active}
-    assert Status.value_to_name(2) == {:ok, :inactive}
-    assert Status.value_to_name(6) == {:ok, :banned}
-    assert Status.value_to_name(32) == {:ok, :evil}
+    assert Status.value_to_name(1) == {:ok, :ACTIVE}
+    assert Status.value_to_name(2) == {:ok, :INACTIVE}
+    assert Status.value_to_name(6) == {:ok, :BANNED}
+    assert Status.value_to_name(32) == {:ok, :EVIL}
     assert Status.value_to_name(65536) == {:error, {:invalid_enum_value, 65536}}
 
-    assert Status.value_to_name!(1) == :active
-    assert Status.value_to_name!(2) == :inactive
-    assert Status.value_to_name!(6) == :banned
-    assert Status.value_to_name!(32) == :evil
+    assert Status.value_to_name!(1) == :ACTIVE
+    assert Status.value_to_name!(2) == :INACTIVE
+    assert Status.value_to_name!(6) == :BANNED
+    assert Status.value_to_name!(32) == :EVIL
     assert_raise MatchError, fn -> Status.value_to_name!(38210) end
 
-    assert Status.name_to_value(:active) == {:ok, 1}
-    assert Status.name_to_value(:inactive) == {:ok, 2}
-    assert Status.name_to_value(:banned) == {:ok, 6}
-    assert Status.name_to_value(:evil) == {:ok, 32}
+    assert Status.name_to_value(:ACTIVE) == {:ok, 1}
+    assert Status.name_to_value(:INACTIVE) == {:ok, 2}
+    assert Status.name_to_value(:BANNED) == {:ok, 6}
+    assert Status.name_to_value(:EVIL) == {:ok, 32}
     assert Status.name_to_value(:just_weird) ==
       {:error, {:invalid_enum_name, :just_weird}}
 
-    assert Status.name_to_value!(:active) == 1
-    assert Status.name_to_value!(:inactive) == 2
-    assert Status.name_to_value!(:banned) == 6
-    assert Status.name_to_value!(:evil) == 32
+    assert Status.name_to_value!(:ACTIVE) == 1
+    assert Status.name_to_value!(:INACTIVE) == 2
+    assert Status.name_to_value!(:BANNED) == 6
+    assert Status.name_to_value!(:EVIL) == 32
     assert_raise MatchError, fn -> Status.name_to_value!(:just_weird) end
 
-    assert Status.meta(:names) == [:active, :inactive, :banned, :evil]
+    assert Status.meta(:names) == [:ACTIVE, :INACTIVE, :BANNED, :EVIL]
     assert Status.meta(:values) == [1, 2, 6, 32]
 
     struct = %StructWithEnum{}
     assert struct.status_field == nil
-    assert struct.status_field_with_default == Status.inactive
+    assert struct.status_field_with_default == :INACTIVE
     assert struct.status_map == nil
     assert struct.status_set == nil
     assert struct.status_list == nil
   end
 
   thrift_test "generated enums that conflict with Elixir keywords" do
-    assert Operator.and == 0
-    assert Operator.member?(0) == true
-    assert Operator.name?(:and) == true
-    assert Operator.value_to_name(0) == {:ok, :and}
-    assert Operator.value_to_name!(0) == :and
-    assert Operator.name_to_value(:and) == {:ok, 0}
-    assert Operator.name_to_value!(:and) == 0
-    assert Operator.meta(:names) == [:and]
+    assert Operator.member?(:AND) == true
+    assert Operator.value_to_name(0) == {:ok, :AND}
+    assert Operator.value_to_name!(0) == :AND
+    assert Operator.name_to_value(:AND) == {:ok, 0}
+    assert Operator.name_to_value!(:AND) == 0
+    assert Operator.meta(:names) == [:AND]
     assert Operator.meta(:values) == [0]
   end
 

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -32,8 +32,8 @@ defmodule BinaryProtocolTest do
     decoder = {Erlang.Enums, :deserialize_struct_with_enum}
 
     assert {:StructWithEnum, :undefined} == round_trip_struct(StructWithEnum.new, encoder, decoder)
-    assert {:StructWithEnum, 32} == round_trip_struct(%StructWithEnum{status: Status.evil}, encoder, decoder)
-    assert {:StructWithEnum, 6} == round_trip_struct(%StructWithEnum{status: Status.banned}, encoder, decoder)
+    assert {:StructWithEnum, 32} == round_trip_struct(%StructWithEnum{status: :EVIL}, encoder, decoder)
+    assert {:StructWithEnum, 6} == round_trip_struct(%StructWithEnum{status: :BANNED}, encoder, decoder)
   end
 
   @thrift_file name: "scalars.thrift", contents: """
@@ -117,16 +117,12 @@ defmodule BinaryProtocolTest do
     assert Erlang.Containers.new_containers(users: []) == round_trip_struct(%Containers{users: []}, encoder, decoder)
 
     # containers can contain enums
-    forecast = [Weather.sunny,
-                Weather.sunny,
-                Weather.sunny,
-                Weather.sunny,
-                Weather.cloudy,
-                Weather.sunny,
-                Weather.sunny]
-    assert Erlang.Containers.new_containers(weekly_forecast: [1, 1, 1, 1, 2, 1, 1]) == round_trip_struct(%Containers{weekly_forecast: forecast}, encoder, decoder)
+    forecast = [:SUNNY, :SUNNY, :SUNNY, :SUNNY, :CLOUDY, :SUNNY, :SUNNY]
+    assert Erlang.Containers.new_containers(weekly_forecast: [1, 1, 1, 1, 2, 1, 1]) ==
+        round_trip_struct(%Containers{weekly_forecast: forecast}, encoder, decoder)
     taken_usernames = ["scohen", "pguillory"]
-    assert Erlang.Containers.new_containers(taken_usernames: :sets.from_list(taken_usernames)) == round_trip_struct(%Containers{taken_usernames: MapSet.new(taken_usernames)}, encoder, decoder)
+    assert Erlang.Containers.new_containers(taken_usernames: :sets.from_list(taken_usernames)) ==
+        round_trip_struct(%Containers{taken_usernames: MapSet.new(taken_usernames)}, encoder, decoder)
 
     # # containers can contain structs
     # erlang_friends = [


### PR DESCRIPTION
Previously, deserializing an enum value would yield an integer. Since you would
not want to hard code these integers into your Elixir code, and because they're
essentially unreadable, we generated macros/functions to convert back and forth
between enum names and values.

With this commit, enum values are deserialized as atoms, which is more
idiomatic and people should generally be able to work with directly.

We still generate the macros, which should provide some backwards
compatibility. They generate a deprecation warning when used. At some point in
the future we should remove them completely.

The atoms used match the enum definitions exactly. We no longer need to worry
about manipulating the case and adding underscores to generate valid Elixir
identifiers.

Closes #312.