### PR TITLE
Switch to using "Error" as our exception suffix

### DIFF
--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-next-line
 defmodule Thrift.TApplicationException do
   @moduledoc """
   Application-level exception
@@ -46,7 +47,7 @@ defmodule Thrift.TApplicationException do
   defp normalize_type(type) when is_integer(type), do: :unknown
 end
 
-defmodule Thrift.Union.TooManyFieldsSetException do
+defmodule Thrift.Union.TooManyFieldsSetError do
   @moduledoc """
   This exception occurs when a Union is serialized and more than one
   field is set.
@@ -55,7 +56,7 @@ defmodule Thrift.Union.TooManyFieldsSetException do
   defexception message: nil, set_fields: nil
 end
 
-defmodule Thrift.FileParseException do
+defmodule Thrift.FileParseError do
   @moduledoc """
   This exception occurs when a thrift file fails to parse
   """
@@ -67,7 +68,7 @@ defmodule Thrift.FileParseException do
   @spec exception({Thrift.Parser.FileRef.t, term}) :: Exception.t
   def exception({file_ref, error}) do
     msg = "Error parsing thrift file #{file_ref.path} #{format_error(error)}"
-    %Thrift.FileParseException{message: msg}
+    %__MODULE__{message: msg}
   end
 
   # display the line number if we get it
@@ -82,7 +83,7 @@ defmodule Thrift.FileParseException do
   end
 end
 
-defmodule Thrift.InvalidValueException do
+defmodule Thrift.InvalidValueError do
   @enforce_keys [:message]
   defexception message: nil
 end

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -743,7 +743,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
           {key, _} -> [key]
         end)
 
-        raise %Thrift.Union.TooManyFieldsSetException{
+        raise %Thrift.Union.TooManyFieldsSetError{
           message: "Thrift union has more than one field set",
           set_fields: set_fields
         }
@@ -774,7 +774,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         true ->
           <<unquote(Type.bool), unquote(id)::16-signed, 1>>
         _ ->
-          raise Thrift.InvalidValueException,
+          raise Thrift.InvalidValueError,
                 unquote("Required boolean field #{inspect name} on #{inspect struct_name} must be true or false")
       end
     end
@@ -789,7 +789,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
         true ->
           <<unquote(Type.bool), unquote(id)::16-signed, 1>>
         _ ->
-          raise Thrift.InvalidValueException,
+          raise Thrift.InvalidValueError,
                 unquote("Optional boolean field #{inspect name} on #{inspect struct_name} must be true, false, or nil")
       end
     end
@@ -798,7 +798,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     quote do
       case unquote(Macro.var(name, nil)) do
         nil ->
-          raise Thrift.InvalidValueException,
+          raise Thrift.InvalidValueError,
                 unquote("Required field #{inspect name} on #{inspect struct_name} must not be nil")
         _ ->
           unquote(required_field_serializer(field, file_group))

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -221,7 +221,7 @@ defmodule Thrift.Parser.Models do
           set_fields ->
 
             field_names = Enum.map(set_fields, &elem(&1, 0))
-            raise %Thrift.Union.TooManyFieldsSetException{
+            raise %Thrift.Union.TooManyFieldsSetError{
               message: "Thrift union has more than one field set",
               set_fields: field_names
             }

--- a/lib/thrift/parser/parsed_file.ex
+++ b/lib/thrift/parser/parsed_file.ex
@@ -16,7 +16,7 @@ defmodule Thrift.Parser.ParsedFile do
                     name: FileRef.include_name(file_ref.path)
                    }
       {:error, error} ->
-        raise Thrift.FileParseException, {file_ref, error}
+        raise Thrift.FileParseError, {file_ref, error}
     end
   end
 end

--- a/test/thrift/generator/binary_protocol_test.exs
+++ b/test/thrift/generator/binary_protocol_test.exs
@@ -2,7 +2,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
   use ThriftTestCase
 
   alias Thrift.Protocol.Binary
-  alias Thrift.Union.TooManyFieldsSetException
+  alias Thrift.Union.TooManyFieldsSetError
 
   def assert_serializes(%{__struct__: mod} = struct, binary) do
     assert binary == IO.iodata_to_binary(Binary.serialize(:struct, struct))
@@ -281,7 +281,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
     assert_serializes %Union{string_field: "hello"},                  <<11, 0, 3, 0, 0, 0, 5, "hello", 0>>
     assert_serializes %Union{list_field: [5, 9, 7]},                  <<15, 0, 4, 6, 0, 0, 0, 3, 0, 5, 0, 9, 0, 7, 0>>
 
-    assert_raise TooManyFieldsSetException, fn ->
+    assert_raise TooManyFieldsSetError, fn ->
       Binary.serialize(:union, %Union{int_field: 205, list_field: [1, 2]})
     end
   end
@@ -296,7 +296,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
                                                                       <<14, 0, 3, 12, 0, 0, 0, 1, 10, 0, 1, 0, 0, 0, 0, 0, 0, 8, 191, 0, 0>>
     assert_serializes %UStruct{u_list: [%Union{int_field: 1291}]},    <<15, 0, 4, 12, 0, 0, 0, 1, 10, 0, 1, 0, 0, 0, 0, 0, 0, 5, 11, 0, 0>>
 
-    assert_raise TooManyFieldsSetException, fn ->
+    assert_raise TooManyFieldsSetError, fn ->
       Binary.serialize(:struct,  %UStruct{my_union: %Union{int_field: 123, string_field: "oops"}})
     end
   end
@@ -408,7 +408,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
 
   thrift_test "required boolean fields must not be nil during serialization" do
     message = "Required boolean field :val on Thrift.Generator.BinaryProtocolTest.RequiredBool must be true or false"
-    assert_raise Thrift.InvalidValueException, message, fn ->
+    assert_raise Thrift.InvalidValueError, message, fn ->
       RequiredBool.serialize(%RequiredBool{})
     end
   end
@@ -425,7 +425,7 @@ defmodule Thrift.Generator.BinaryProtocolTest do
 
   thrift_test "required fields must not be nil during serialization" do
     message = "Required field :val on Thrift.Generator.BinaryProtocolTest.RequiredField must not be nil"
-    assert_raise Thrift.InvalidValueException, message, fn ->
+    assert_raise Thrift.InvalidValueError, message, fn ->
       RequiredField.serialize(%RequiredField{})
     end
   end

--- a/test/thrift/parser/parse_error_test.exs
+++ b/test/thrift/parser/parse_error_test.exs
@@ -25,7 +25,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     File.write!(path, contents)
 
     assert_raise(
-      Thrift.FileParseException,
+      Thrift.FileParseError,
       ~r/#{path} on line 1:/,
       fn -> parse_file(path) end
     )
@@ -42,7 +42,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     # should raise an error on the included file,
     # since that is where the syntax error is
     assert_raise(
-      Thrift.FileParseException,
+      Thrift.FileParseError,
       ~r/#{path} on line 1:/,
       fn -> parse_file(other_path) end
     )
@@ -60,7 +60,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     File.write!(path, contents)
 
     assert_raise(
-      Thrift.FileParseException,
+      Thrift.FileParseError,
       ~r/#{path} on line 2:/,
       fn -> parse_file(path) end
     )
@@ -77,7 +77,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     # should raise an error on the included file,
     # since that is where the syntax error is
     assert_raise(
-      Thrift.FileParseException,
+      Thrift.FileParseError,
       ~r/#{path} on line 2:/,
       fn -> parse_file(other_path) end
     )


### PR DESCRIPTION
This is more consistent with Elixir's own naming conventions. It also
removes a small amount of ambiguity with code that refers to Thrift's
exceptions; that is, things named "exceptions" in this library are
nearly all Thrift exceptions.