### PR TITLE
Avoid using String.Casing.titlecase_once/1

### DIFF
--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -224,11 +224,12 @@ defmodule Thrift.Parser.FileGroup do
   end
 
   # Capitalize just the initial character of a string, leaving the rest of the
-  # string's characters intact.
+  # string's characters intact. Note that this currently assumes ASCII string
+  # characters.
   @spec initialcase(String.t) :: String.t
-  defp initialcase(string) when is_binary(string) do
-    {char, rest} = String.Casing.titlecase_once(string)
-    char <> rest
+  defp initialcase(<<char, rest::binary>>) do
+    char = if char >= ?a and char <= ?z, do: char - 32, else: char
+    <<char>> <> rest
   end
 
   # check if the given model is defined in the root file of the file group

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -224,12 +224,11 @@ defmodule Thrift.Parser.FileGroup do
   end
 
   # Capitalize just the initial character of a string, leaving the rest of the
-  # string's characters intact. Note that this currently assumes ASCII string
-  # characters.
+  # string's characters intact.
   @spec initialcase(String.t) :: String.t
-  defp initialcase(<<char, rest::binary>>) do
-    char = if char >= ?a and char <= ?z, do: char - 32, else: char
-    <<char>> <> rest
+  defp initialcase(string) when is_binary(string) do
+    {first, rest} = String.next_grapheme(string)
+    String.upcase(first) <> rest
   end
 
   # check if the given model is defined in the root file of the file group


### PR DESCRIPTION
This is a private Elixir library function, and its arity changed to
`/2` in Elixir 1.6 to support a new `mode` parameter.

Instead, we can just perform the "upcase" transformation ourselves if we
assume the names only contain ASCII characters, which is reasonable in
this context.