### PR TITLE
Support Elixir 1.6 setup_all context change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
     - elixir: 1.6
       otp_release: 20.2
       env: COVERALLS=true
-  allow_failures:
-    - elixir: 1.6
 
 sudo: required
 dist: trusty

--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -115,7 +115,8 @@ defmodule ThriftTestCase do
     end
   end
 
-  setup_all %{case: module} do
+  setup_all context do
+    module = context[:module] || context[:case]
     attributes = module.__info__(:attributes)
     opts = attributes[:thrift_test_opts]
     [dir] = attributes[:thrift_test_dir]


### PR DESCRIPTION
Elixir 1.6's ExUnit implementation [changed](https://github.com/elixir-lang/elixir/commit/23c7542d95683a497a7b93071b9ccbbeb9e45d2f#r27187159) such that setup_all's
`context` now contains a `:module` key instead of a `:case` key.
Backwards compatibility was intended, but it looks like the ExUnit
runner now only passes `:module`.