### PR TITLE
Fix gen_server_opts not being passed to GenServer

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -81,15 +81,13 @@ defmodule Thrift.Binary.Framed.Client do
 
      - `send_timeout`: An integer that governs how long our connection waits when sending data.
 
-     - `gen_server_opts`: A keyword list of options that control the gen_server behaviour.
-
-     - `timeout`:  The amount of time to wait (in milliseconds) for a reply from a `GenServer` call.
-
+  Additionally, the options `:name`, `:debug`, and `:spawn_opt`, if specified, will be passed to
+  the underlying `GenServer`. See `GenServer.start_link/3` for details on these options.
   """
   @spec start_link(String.t, (0..65_535), options) :: GenServer.on_start
   def start_link(host, port, opts) do
-    {gen_server_opts, opts} = Keyword.pop(opts, :gen_server_opts, [])
-    Connection.start_link(__MODULE__, {host, port, opts}, gen_server_opts)
+    {gen_server_opts, client_opts} = Keyword.split(opts, [:debug, :name, :spawn_opt])
+    Connection.start_link(__MODULE__, {host, port, client_opts}, gen_server_opts)
   end
 
   @doc """

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -81,14 +81,15 @@ defmodule Thrift.Binary.Framed.Client do
 
      - `send_timeout`: An integer that governs how long our connection waits when sending data.
 
-    `gen_server_opts`: A keyword list of options that control the gen_server behaviour.
+     - `gen_server_opts`: A keyword list of options that control the gen_server behaviour.
 
      - `timeout`:  The amount of time to wait (in milliseconds) for a reply from a `GenServer` call.
 
   """
   @spec start_link(String.t, (0..65_535), options) :: GenServer.on_start
   def start_link(host, port, opts) do
-    Connection.start_link(__MODULE__, {host, port, opts})
+    {gen_server_opts, opts} = Keyword.pop(opts, :gen_server_opts, [])
+    Connection.start_link(__MODULE__, {host, port, opts}, gen_server_opts)
   end
 
   @doc """

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -108,7 +108,7 @@ defmodule Servers.Binary.Framed.IntegrationTest do
       end
     end
 
-    {:ok, client} = Client.start_link("localhost", ctx.port, [gen_server_opts: [name: TestClientName]])
+    {:ok, client} = Client.start_link("localhost", ctx.port, name: TestClientName)
 
     {:ok, client: client}
   end
@@ -176,7 +176,7 @@ defmodule Servers.Binary.Framed.IntegrationTest do
     assert ctx.client == Process.whereis(TestClientName)
   end
 
-  thrift_test "client methods can be called by name instead of pid", ctx do
+  thrift_test "client methods can be called by name instead of pid", _ctx do
     assert {:ok, true} == Client.ping(TestClientName)
   end
 end

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -108,7 +108,7 @@ defmodule Servers.Binary.Framed.IntegrationTest do
       end
     end
 
-    {:ok, client} = Client.start_link("localhost", ctx.port, [])
+    {:ok, client} = Client.start_link("localhost", ctx.port, [gen_server_opts: [name: TestClientName]])
 
     {:ok, client: client}
   end
@@ -170,5 +170,13 @@ defmodule Servers.Binary.Framed.IntegrationTest do
 
     :timer.sleep 100
     assert "username" == Agent.get(:server_args, &(&1))
+  end
+
+  thrift_test "client can be found by name", ctx do
+    assert ctx.client == Process.whereis(TestClientName)
+  end
+
+  thrift_test "client methods can be called by name instead of pid", ctx do
+    assert {:ok, true} == Client.ping(TestClientName)
   end
 end


### PR DESCRIPTION
In the docs, the `gen_server_opts` option was listed, but not actually hooked up to pass the opts to the `GenServer` handlers.
This fixes #172, and the tests I added verify that.