### PR TITLE
Avoid redefining generated in memory only modules

### DIFF
--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -171,6 +171,9 @@ defmodule ThriftTestCase do
       {:file, ^source_file} ->
         true
       {:file, :in_memory} ->
+        # TODO: remove clause when Elixir ~> 1.6 as replaced by [] (atom broke spec)
+        true
+      {:file, []} ->
         true
       _ ->
         false


### PR DESCRIPTION
`:in_memory` broke the type contract so Elixir 1.6 switched to using `[]`, an empty list/path. Empty list is often used as `nil` in Erlang.