### PR TITLE
Corrects the thrift example definition in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ struct User {
 }
 
 service UserService {
-  1: bool ping(),
-  2: User get_user_by_id(1: i64 user_id) throws (1: UserNotFound unf),
-  3: boolean deleteUser(1: i64 userId),
+  bool ping(),
+  User get_user_by_id(1: i64 user_id) throws (1: UserNotFound unf),
+  bool deleteUser(1: i64 userId),
 }
 ```
 


### PR DESCRIPTION
I am new to Thrift so was working through the README. Using the example thrift definition results in

```
Failed to parse thrift/user.thrift: Error parsing thrift file thrift/user.thrift on line 13: syntax error before: 1
```

Removing the "field numbers" from the server procedure definitions works. Scanning through https://thrift.apache.org it does seem correct.

(Also changed  the return type def of `deleteUser` from `boolean` to `bool`.)