### PR TITLE
Fix bug with enum numbering

### DIFF
--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -61,17 +61,15 @@ defmodule Thrift.Parser.Models do
 
     @spec new(charlist, %{charlist => enum_value}) :: t
     def new(name, values) do
-      values = values
-      |> Enum.with_index
-      |> Enum.map(fn
-        {{name, value}, _index} ->
-          {atomify(name), value}
-
-        {name, index} ->
-          {atomify(name), index + 1}
+      {_, values} = values
+      |> Enum.reduce({1, []}, fn
+        {name, value}, {_index, acc} ->
+          {value + 1, [{atomify(name), value} | acc]}
+        name, {index, acc} ->
+          {index + 1, [{atomify(name), index} | acc]}
       end)
 
-      %TEnum{name: atomify(name), values: values}
+      %TEnum{name: atomify(name), values: Enum.reverse(values)}
     end
   end
 

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -61,7 +61,7 @@ defmodule Thrift.Parser.Models do
 
     @spec new(charlist, %{charlist => enum_value}) :: t
     def new(name, values) do
-      {_, values} = Enum.reduce(values, {1, []}, fn
+      {_, values} = Enum.reduce(values, {0, []}, fn
         {name, value}, {_index, acc} ->
           {value + 1, [{atomify(name), value} | acc]}
         name, {index, acc} ->

--- a/lib/thrift/parser/models.ex
+++ b/lib/thrift/parser/models.ex
@@ -61,8 +61,7 @@ defmodule Thrift.Parser.Models do
 
     @spec new(charlist, %{charlist => enum_value}) :: t
     def new(name, values) do
-      {_, values} = values
-      |> Enum.reduce({1, []}, fn
+      {_, values} = Enum.reduce(values, {1, []}, fn
         {name, value}, {_index, acc} ->
           {value + 1, [{atomify(name), value} | acc]}
         name, {index, acc} ->

--- a/test/thrift/generator/models_test.exs
+++ b/test/thrift/generator/models_test.exs
@@ -21,14 +21,14 @@ defmodule Thrift.Generator.ModelsTest do
   """
 
   thrift_test "generating enum" do
-    assert Status.active == 1
-    assert Status.inactive == 2
+    assert Status.active == 0
+    assert Status.inactive == 1
     assert Status.banned == 6
     assert Status.evil == 32
 
-    assert Status.member?(0) == false
+    assert Status.member?(0) == true
     assert Status.member?(1) == true
-    assert Status.member?(2) == true
+    assert Status.member?(2) == false
     assert Status.member?(3) == false
     assert Status.member?(4) == false
     assert Status.member?(5) == false
@@ -41,33 +41,33 @@ defmodule Thrift.Generator.ModelsTest do
     assert Status.name?(:evil) == true
     assert Status.name?(:bamboozled) == false
 
-    assert Status.value_to_name(1) == {:ok, :active}
-    assert Status.value_to_name(2) == {:ok, :inactive}
+    assert Status.value_to_name(0) == {:ok, :active}
+    assert Status.value_to_name(1) == {:ok, :inactive}
     assert Status.value_to_name(6) == {:ok, :banned}
     assert Status.value_to_name(32) == {:ok, :evil}
     assert Status.value_to_name(65536) == {:error, {:invalid_enum_value, 65536}}
 
-    assert Status.value_to_name!(1) == :active
-    assert Status.value_to_name!(2) == :inactive
+    assert Status.value_to_name!(0) == :active
+    assert Status.value_to_name!(1) == :inactive
     assert Status.value_to_name!(6) == :banned
     assert Status.value_to_name!(32) == :evil
     assert_raise MatchError, fn -> Status.value_to_name!(38210) end
 
-    assert Status.name_to_value(:active) == {:ok, 1}
-    assert Status.name_to_value(:inactive) == {:ok, 2}
+    assert Status.name_to_value(:active) == {:ok, 0}
+    assert Status.name_to_value(:inactive) == {:ok, 1}
     assert Status.name_to_value(:banned) == {:ok, 6}
     assert Status.name_to_value(:evil) == {:ok, 32}
     assert Status.name_to_value(:just_weird) ==
       {:error, {:invalid_enum_name, :just_weird}}
 
-    assert Status.name_to_value!(:active) == 1
-    assert Status.name_to_value!(:inactive) == 2
+    assert Status.name_to_value!(:active) == 0
+    assert Status.name_to_value!(:inactive) == 1
     assert Status.name_to_value!(:banned) == 6
     assert Status.name_to_value!(:evil) == 32
     assert_raise MatchError, fn -> Status.name_to_value!(:just_weird) end
 
     assert Status.meta(:names) == [:active, :inactive, :banned, :evil]
-    assert Status.meta(:values) == [1, 2, 6, 32]
+    assert Status.meta(:values) == [0, 1, 6, 32]
 
     struct = %StructWithEnum{}
     assert struct.status_field == nil

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -278,7 +278,7 @@ defmodule Thrift.Parser.ParserTest do
 
     assert user_status == %TEnum{line: 1,
                                  name: :UserStatus,
-                                 values: [ACTIVE: 1, INACTIVE: 2, BANNED: 6, EVIL: 32]}
+                                 values: [ACTIVE: 0, INACTIVE: 1, BANNED: 6, EVIL: 32]}
   end
 
   test "parsing an enum with awkward numbering" do

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -281,6 +281,23 @@ defmodule Thrift.Parser.ParserTest do
                                  values: [ACTIVE: 1, INACTIVE: 2, BANNED: 6, EVIL: 32]}
   end
 
+  test "parsing an enum with awkward numbering" do
+    user_status = parse("""
+    enum Numberz {
+      ONE = 1,
+      TWO,
+      THREE,
+      FIVE = 5,
+      SIX,
+      EIGHT = 8
+    }
+    """, [:enums, :Numberz])
+
+    assert user_status == %TEnum{line: 1,
+                                 name: :Numberz,
+                                 values: [ONE: 1, TWO: 2, THREE: 3, FIVE: 5, SIX: 6, EIGHT: 8]}
+  end
+
   test "parsing an exception" do
     program = """
     exception ApplicationException {

--- a/test/thrift/parser/resolver_test.exs
+++ b/test/thrift/parser/resolver_test.exs
@@ -123,7 +123,7 @@ defmodule ResolverTest do
 
       user_state = FileGroup.resolve(file_group, :"states.UserState")
 
-      assert %TEnum{values: [ACTIVE: 1, LAPSED: 2, DISABLED: 3]} = user_state
+      assert %TEnum{values: [ACTIVE: 0, LAPSED: 1, DISABLED: 2]} = user_state
       assert user_state.name == :"states.UserState"
     end
 
@@ -216,14 +216,14 @@ defmodule ResolverTest do
 
       sort1 = FileGroup.resolve(file_group, :"local.SORT1")
       assert %TEnum{name: :"local.SortType"} = FileGroup.resolve(file_group, sort1.type)
-      assert 2 == FileGroup.resolve(file_group, sort1.value)
+      assert 1 == FileGroup.resolve(file_group, sort1.value)
 
       sort2 = FileGroup.resolve(file_group, :"local.SORT2")
       assert %TEnum{name: :"included.SortType"} = FileGroup.resolve(file_group, sort2.type)
       assert 110 == FileGroup.resolve(file_group, sort2.value)
 
       local_sort = FileGroup.resolve(file_group, :SortType)
-      assert %TEnum{name: :"local.SortType", values: [DESC: 1, ASC: 2], line: 2} == local_sort
+      assert %TEnum{name: :"local.SortType", values: [DESC: 0, ASC: 1], line: 2} == local_sort
     end
   end
 end

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -124,7 +124,7 @@ defmodule BinaryProtocolTest do
                 Weather.cloudy,
                 Weather.sunny,
                 Weather.sunny]
-    assert Erlang.Containers.new_containers(weekly_forecast: [1, 1, 1, 1, 2, 1, 1]) == round_trip_struct(%Containers{weekly_forecast: forecast}, encoder, decoder)
+    assert Erlang.Containers.new_containers(weekly_forecast: [0, 0, 0, 0, 1, 0, 0]) == round_trip_struct(%Containers{weekly_forecast: forecast}, encoder, decoder)
     taken_usernames = ["scohen", "pguillory"]
     assert Erlang.Containers.new_containers(taken_usernames: :sets.from_list(taken_usernames)) == round_trip_struct(%Containers{taken_usernames: MapSet.new(taken_usernames)}, encoder, decoder)
 


### PR DESCRIPTION
There's a thrift definition in `test/fixtures/app/thrift/ThriftTest.thrift` called `Numberz` that looks like this:
```thrift
enum Numberz {
  ONE = 1,
  TWO,
  THREE,
  FIVE = 5,
  SIX,
  EIGHT = 8
}
```
Our previous solution was using `Enum.with_index` to assign indices, with special cases for those with special values. However, for this particular (malicious!) code, it resulted in
```elixir
...
  def(value_to_name(5)) do
    {:ok, :five}
  end
  def(value_to_name(5)) do
    {:ok, :six}
  end
...
```
and some other bad stuff showing up in our generated code.