### PR TITLE
Test against OTP 20.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
     - elixir: 1.5
       otp_release: 19.3
     - elixir: 1.6
-      otp_release: 19.3
-    - elixir: 1.6
-      otp_release: 20.2
+      otp_release: 20.3
       env: COVERALLS=true
 
 sudo: required


### PR DESCRIPTION
Also remove the Elixir 1.6 / OTP 20.3 entry from the matrix to speed up
our CI builds a bit more. That isn't a unique-enough combination to
justify its own testing environment.