### PR TITLE
"Generate" -> "Generates" for `thrift.generate`

### DIFF
--- a/lib/mix/tasks/thrift.generate.ex
+++ b/lib/mix/tasks/thrift.generate.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Thrift.Generate do
   use Mix.Task
 
-  @shortdoc "Generate Elixir source files from Thrift schema files"
+  @shortdoc "Generates Elixir source files from Thrift schema files"
 
   @moduledoc """
   Generate Elixir source files from Thrift schema files (`.thrift`).


### PR DESCRIPTION
This is consistent with the @shortdoc comments of other mix tasks.