### PR TITLE
Support comment-based namespace declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,29 @@ UserService Framed Binary Client | lib/thrift/test/user_service.ex |`Thrift.Test
 UserService Framed Binary Server | lib/thrift/test/user_service.ex | `Thrift.Test.UserService.Binary.Framed.Server`
 UserService Handler Behviour (Used for writing servers) | lib/thrift/test_user_service/handler.ex  | `Thrift.Test.UserService.Handler`
 
+### Namespaces
+
+Thrift uses the `namespace` keyword to define a language's namespace. From the
+previous example:
+
+```thrift
+namespace elixir Thrift.Test
+```
+
+Unfortunately, the Apache Thrift compiler will produce a warning on this line
+because it doesn't recognize `elixir` as a supported language. While that
+warning is benign, it can be annoying. For that reason, you can also specify
+your Elixir namespace as a "magic" namespace comment:
+
+```thrift
+#@namespace elixir Thrift.Test
+```
+
+This alternate syntax is borrowed from [Scrooge][], which uses the same trick
+for defining `scala` namespaces.
+
+[Scrooge]: https://twitter.github.io/scrooge/Namespaces.html
+
 
 ## Using the Client
 The client includes a static module that does most of the work, and a generated

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -17,7 +17,8 @@ Definitions.
 WHITESPACE      = [\s\t\r\n]+
 COMMENT         = //[^\n]*
 CCOMMENT        = /\*/*([^*/]|[^*]/|\*[^/])*\**\*/
-UNIXCOMMENT     = #[^\n]*
+NSCOMMENT       = #@namespace
+UNIXCOMMENT     = #[^@][^\n]*
 COMMENTS        = {COMMENT}|{CCOMMENT}|{UNIXCOMMENT}
 
 INT             = [+-]?[0-9]+
@@ -56,6 +57,7 @@ Rules.
 {COMMENTS}      : skip_token.
 
 __file__        : {token, {file, TokenLine}}.
+{NSCOMMENT}     : {token, {namespace, TokenLine}}.
 {PUNCTUATOR}    : {token, {list_to_atom(TokenChars), TokenLine}}.
 {KEYWORD}       : {token, {list_to_atom(TokenChars), TokenLine}}.
 

--- a/test/thrift/parser/lexer_test.exs
+++ b/test/thrift/parser/lexer_test.exs
@@ -78,6 +78,10 @@ defmodule Thrift.Parser.LexerTest do
     end
   end
 
+  test "namespace comment" do
+    assert tokenize("#@namespace") == [namespace: 1]
+  end
+
   test "boolean literals" do
     assert tokenize("true") == [true: 1]
     assert tokenize("false") == [false: 1]
@@ -247,11 +251,13 @@ defmodule Thrift.Parser.LexerTest do
       namespace py foo.bar.baz
       namespace java com.pinterest.foo.bar.baz
       namespace * foo.bar
+      #@namespace elixir Bar
     """) == [
       {:namespace, 1}, {:ident, 1, 'elixir'}, {:ident, 1, 'Foo'},
       {:namespace, 2}, {:ident, 2, 'py'}, {:ident, 2, 'foo.bar.baz'},
       {:namespace, 3}, {:ident, 3, 'java'}, {:ident, 3, 'com.pinterest.foo.bar.baz'},
-      {:namespace, 4}, {:*, 4}, {:ident, 4, 'foo.bar'}]
+      {:namespace, 4}, {:*, 4}, {:ident, 4, 'foo.bar'},
+      {:namespace, 5}, {:ident, 5, 'elixir'}, {:ident, 5, 'Bar'}]
   end
 
   test "a const definition" do

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -61,11 +61,13 @@ defmodule Thrift.Parser.ParserTest do
     namespace py foo.bar.baz
     namespace erl foo_bar
     namespace * bar.baz
+    #@namespace elixir Foo
     """, [:namespaces])
 
     assert namespaces[:py] == %Namespace{line: 1, name: :py, path: "foo.bar.baz"}
     assert namespaces[:erl] == %Namespace{line: 2, name: :erl, path: "foo_bar"}
     assert namespaces[:*] == %Namespace{line: 3, name: :*, path: "bar.baz"}
+    assert namespaces[:elixir] == %Namespace{line: 4, name: :elixir, path: "Foo"}
   end
 
   test "parsing include headers" do


### PR DESCRIPTION
Thrift uses the `namespace` keyword to define a language's namespace.

    namespace elixir Thrift.Namespace

Unfortunately, the Apache Thrift compiler will produce a warning on this
line because it doesn't recognize `elixir` as a supported language.
While that warning is benign, it can be annoying. For that reason, you
can also specify your Elixir namespace as a "magic" namespace comment:

    #@namespace elixir Thrift.Namespace

This alternate syntax is borrowed from Scrooge, which uses the same
trick for defining `scala` namespaces.