### PR TITLE
Add option for allowing both SSL and plain connections on same port

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Name             | Type | Description
 Name             | Type | Description
 -----------------|------|---------------
 `:enabled`       | boolean | Whether to upgrade the connection to the SSL protocol.
+`:optional`      | boolean | Whether to accept both SSL and plain connections.
 `:configure`     | 0-arity fun | A function to provide additional SSL options at run time.
 `ssloption`      | :ssl.ssloption | Other standard [`:ssl` options](http://erlang.org/doc/man/ssl.html).
 

--- a/lib/thrift/transport/ssl.ex
+++ b/lib/thrift/transport/ssl.ex
@@ -7,6 +7,7 @@ defmodule Thrift.Transport.SSL do
 
   ## Options
       * :enabled - Whether ssl is enabled (default: `false`)
+      * :optional - Whether to accept both SSL and plain connections (default: `false`)
       * :configure - Get extra configuration at handshake time (default: `nil`)
 
   ## Delayed configure option
@@ -18,9 +19,9 @@ defmodule Thrift.Transport.SSL do
   """
 
   @type configure :: {module, function, list} | (() -> ({:ok, [option]} | {:error, Exception.t}))
-  @type option :: :ssl.ssloption | {:enabled, boolean} | {:configure, configure}
+  @type option :: :ssl.ssloption | {:enabled, boolean} | {:optional, boolean} | {:configure, configure}
 
-  @spec configuration([option]) :: {:ok, [:ssl.ssloption]} | nil | {:error, Exceptiont.t}
+  @spec configuration([option]) :: {:ok, [:ssl.ssloption | {:optional, boolean}]} | nil | {:error, Exception.t}
   def configuration(opts) do
     case Keyword.pop(opts, :enabled, false) do
       {true, opts} ->
@@ -28,6 +29,11 @@ defmodule Thrift.Transport.SSL do
       {false, _} ->
         nil
     end
+  end
+
+  @spec optional?([option]) :: {boolean, [:ssl.ssloption]} | {:error, Exception.t}
+  def optional?(opts) do
+    Keyword.pop(opts, :optional, false)
   end
 
   defp update_configuration(opts) do

--- a/test/thrift/transport/ssl_test.exs
+++ b/test/thrift/transport/ssl_test.exs
@@ -9,4 +9,11 @@ defmodule Thrift.Transport.SSLTest do
       assert {:error, error} == SSL.configuration([enabled: true, configure: fn -> {:error, error} end])
     end
   end
+
+  describe "optional?/1" do
+    test "does the right thing" do
+      assert {true, [certfile: "/some/path"]} = SSL.optional?([certfile: "/some/path", optional: true])
+      assert {false, [certfile: "/some/path"]} = SSL.optional?([certfile: "/some/path", optional: false])
+    end
+  end
 end


### PR DESCRIPTION
By inspecting the first byte of traffic on the socket, we can determine whether the connection is a plain connection or an SSL connection. By having a single server that handles both connection types, it simplifies operations so we do not need to run two servers on different ports.

`:gen_tcp` makes this difficult as there is no `peek` option for sockets like there are in C, but instead we can recv the first bytes and then `unrecv` them back to the socket. Before doing this though, we ensure that `packet: 4` has not been set.

I added a bunch more tests so we cover a plain client trying to connect to a server that requires SSL, and also the optional cases.