### PR TITLE
Close sockets before exiting

### DIFF
--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -90,6 +90,7 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
     else
       {:error, {:server_error, thrift_data}} ->
         :ok = transport.send(socket, thrift_data)
+        :ok = transport.close(socket)
         exit({:shutdown, :server_error})
 
       {:error, {:protocol_error, reason}} ->


### PR DESCRIPTION
After sending a thrift exception, instead of simply exiting, we should close the socket.
This will ensure the SSL transport properly handshakes during the exit.