### PR TITLE
Move Thrift.Parser.Models to Thrift.AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ files. It is built on a low-level Erlang lexer and parser:
 
 {:ok, schema} = :thrift_parser.parse(tokens)
 {:ok,
- %Thrift.Parser.Models.Schema{constants: %{},
-  enums: %{Colors: %Thrift.Parser.Models.TEnum{name: :Colors,
+ %Thrift.AST.Schema{constants: %{},
+  enums: %{Colors: %Thrift.AST.TEnum{name: :Colors,
      values: [RED: 1, GREEN: 2, BLUE: 3]}}, exceptions: %{}, includes: [],
   namespaces: %{}, services: %{}, structs: %{}, thrift_namespace: nil,
   typedefs: %{}, unions: %{}}}
@@ -323,8 +323,8 @@ But also provides a high-level Elixir parsing interface:
 
 ```elixir
 Thrift.Parser.parse("enum Colors { RED, GREEN, BLUE }")
-%Thrift.Parser.Models.Schema{constants: %{},
- enums: %{Colors: %Thrift.Parser.Models.TEnum{name: :Colors,
+%Thrift.AST.Schema{constants: %{},
+ enums: %{Colors: %Thrift.AST.TEnum{name: :Colors,
     values: [RED: 1, GREEN: 2, BLUE: 3]}}, exceptions: %{}, includes: [],
  namespaces: %{}, services: %{}, structs: %{}, thrift_namespace: nil,
  typedefs: %{}, unions: %{}}

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -2,10 +2,11 @@ defmodule Thrift do
   @moduledoc ~S"""
   Thrift provides [Apache Thrift](http://thrift.apache.org/) support:
 
-    * `Mix.Tasks.Compile.Thrift` - mix task for generate Erlang source files
-      from `.thrift` schema files
+  * `Mix.Tasks.Compile.Thrift` - mix task for generate Erlang source files
+  from `.thrift` schema files
 
-    * `Thrift.Parser` - functions for parsing `.thift` schema files
+  * `Thrift.Parser` - functions for parsing `.thift` schema files into a
+  `Thrift.AST` tree
   """
 
   @typedoc "Thrift data types"

--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -1,8 +1,9 @@
-defmodule Thrift.Parser.Models do
+defmodule Thrift.AST do
   @moduledoc """
-  Models used by the Thrift parser that represent different Thrift components.
-  The models defined here are returned by the parse functions in the
-  `Thrift.Parser` module.
+  Thrift Abstract Syntax Tree
+
+  Parsed Thrift files are repesented as a tree of these structures, starting
+  with a `Thrift.AST.Schema` node.
   """
 
   import Thrift.Parser.Conversions
@@ -352,15 +353,6 @@ defmodule Thrift.Parser.Models do
     exceptions: %{},
     typedefs: %{},
     file_group: nil
-
-    alias Thrift.Parser.Models.{Constant,
-                                Exception,
-                                Include,
-                                Namespace,
-                                Struct,
-                                TEnum,
-                                Union
-                               }
 
     @doc """
     Constructs a schema with both headers and definitions.

--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -4,11 +4,8 @@ defmodule Thrift.Generator do
   IDL files (`.thrift`).
   """
 
-  alias Thrift.Parser.{
-    FileGroup,
-    Models.Schema,
-    Models.Constant
-  }
+  alias Thrift.AST.{Constant, Schema}
+  alias Thrift.Parser.FileGroup
   alias Thrift.{
     Generator,
     Generator.ConstantGenerator,

--- a/lib/thrift/generator/behaviour.ex
+++ b/lib/thrift/generator/behaviour.ex
@@ -6,9 +6,7 @@ defmodule Thrift.Generator.Behaviour do
   to implement. Thrift types are converted into Elixir typespecs that are
   equivalent to their thrift counterparts.
   """
-  alias Thrift.Generator.Utils
-  alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     Exception,
     Field,
     Struct,
@@ -16,6 +14,8 @@ defmodule Thrift.Generator.Behaviour do
     TEnum,
     Union,
   }
+  alias Thrift.Generator.Utils
+  alias Thrift.Parser.FileGroup
 
   require Logger
 

--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -1,8 +1,8 @@
 defmodule Thrift.Generator.Binary.Framed.Client do
   @moduledoc false
 
+  alias Thrift.AST.Function
   alias Thrift.Generator.{Service, Utils}
-  alias Thrift.Parser.Models.Function
 
   def generate(service) do
     functions = service.functions

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -1,11 +1,11 @@
 defmodule Thrift.Generator.Binary.Framed.Server do
   @moduledoc false
+  alias Thrift.AST.Function
   alias Thrift.Generator.{
     Service,
     Utils
   }
   alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.Function
 
   def generate(service_module, service, file_group) do
     functions = service.functions

--- a/lib/thrift/generator/constant_generator.ex
+++ b/lib/thrift/generator/constant_generator.ex
@@ -1,11 +1,8 @@
 defmodule Thrift.Generator.ConstantGenerator do
   @moduledoc false
 
+  alias Thrift.AST.{Constant, Schema}
   alias Thrift.Generator.Utils
-  alias Thrift.Parser.Models.{
-    Constant,
-    Schema,
-  }
 
   @spec generate(atom, [Constant.t], Schema.t) :: Macro.t
   def generate(full_name, constants, schema) do

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -1,16 +1,13 @@
 defmodule Thrift.Generator.Service do
   @moduledoc false
+
+  alias Thrift.AST.{Field, Function, Struct}
   alias Thrift.Parser.FileGroup
   alias Thrift.{
     Generator,
     Generator.StructGenerator,
   }
 
-  alias Thrift.Parser.Models.{
-    Field,
-    Function,
-    Struct
-  }
 
   # The response struct uses a %Field{} to represent the service function's
   # return value. Functions can return :void while fields cannot. Until we can

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -38,9 +38,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
   been generated for that struct.
   """
 
-  alias Thrift.Generator.Utils
-  alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     Exception,
     Field,
     Struct,
@@ -48,6 +46,8 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     TEnum,
     Union,
   }
+  alias Thrift.Generator.Utils
+  alias Thrift.Parser.FileGroup
 
   require Thrift.Protocol.Binary.Type, as: Type
 

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -1,7 +1,5 @@
 defmodule Thrift.Generator.StructGenerator do
-  alias Thrift.Generator.{StructBinaryProtocol, Utils}
-  alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     Exception,
     Field,
     Struct,
@@ -9,6 +7,8 @@ defmodule Thrift.Generator.StructGenerator do
     TEnum,
     Union,
   }
+  alias Thrift.Generator.{StructBinaryProtocol, Utils}
+  alias Thrift.Parser.FileGroup
 
   def generate(label, schema, name, struct) when label in [:struct, :union, :exception] do
     struct_parts = Enum.map(struct.fields, fn

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -3,9 +3,7 @@ defmodule Thrift.Generator.Utils do
   Collection of utilities for working with generated code.
   """
 
-  alias Thrift.NaN
-  alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     Constant,
     Field,
     Struct,
@@ -14,6 +12,8 @@ defmodule Thrift.Generator.Utils do
     TEnum,
     ValueRef,
   }
+  alias Thrift.NaN
+  alias Thrift.Parser.FileGroup
 
   @doc """
   When nesting a quote with multiple defs into another quote, the defs end up

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -3,8 +3,7 @@ defmodule Thrift.Parser do
   This module provides functions for parsing Thrift IDL files (`.thrift`).
   """
 
-  alias Thrift.Parser.{FileGroup, FileRef, Models, ParsedFile}
-  alias Thrift.Parser.Models.Schema
+  alias Thrift.Parser.{FileGroup, FileRef, ParsedFile}
 
   @typedoc "A Thrift IDL line number"
   @type line :: pos_integer | nil
@@ -24,7 +23,7 @@ defmodule Thrift.Parser do
   @doc """
   Parses a Thrift document and returns the schema that it represents.
   """
-  @spec parse(String.t) :: {:ok, Schema.t} | {:error, term}
+  @spec parse(String.t) :: {:ok, Thrift.AST.Schema.t} | {:error, term}
   def parse(doc) do
     doc = String.to_charlist(doc)
 
@@ -48,7 +47,7 @@ defmodule Thrift.Parser do
 
   Will return the "MyService" service.
   """
-  @spec parse(String.t, [path_element, ...]) :: Models.all
+  @spec parse(String.t, [path_element, ...]) :: Thrift.AST.all
   def parse(doc, path) do
     {:ok, schema} = parse(doc)
 

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -16,7 +16,7 @@ defmodule Thrift.Parser.FileGroup do
     ParsedFile
   }
 
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     TEnum,
     Constant,
     Exception,

--- a/lib/thrift/parser/parsed_file.ex
+++ b/lib/thrift/parser/parsed_file.ex
@@ -1,7 +1,7 @@
 defmodule Thrift.Parser.ParsedFile do
   @moduledoc false
 
-  alias Thrift.Parser.Models.Schema
+  alias Thrift.AST.Schema
   alias Thrift.Parser
   alias Thrift.Parser.FileRef
 

--- a/lib/thrift/parser/resolver.ex
+++ b/lib/thrift/parser/resolver.ex
@@ -6,8 +6,8 @@ defmodule Thrift.Parser.Resolver do
   # of names. At the end, the database is dumped into the FileGroup so it can
   # resolve references.
 
+  alias Thrift.AST.TEnum
   alias Thrift.Parser.ParsedFile
-  alias Thrift.Parser.Models.TEnum
 
   def add(state, %ParsedFile{} = f) do
     state

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -43,7 +43,7 @@ Rootsymbol Schema.
 % Schema
 
 Schema -> Headers Definitions File:
-    build_model('Schema', ['$3', '$1', '$2']).
+    build_node('Schema', ['$3', '$1', '$2']).
 
 File -> '$empty': nil.
 File -> file string: 'Elixir.List':to_string(unwrap('$2')).
@@ -57,12 +57,12 @@ Header -> Include: '$1'.
 Header -> Namespace: '$1'.
 
 Include -> include string:
-    build_model('Include', line('$1'), [unwrap('$2')]).
+    build_node('Include', line('$1'), [unwrap('$2')]).
 
 Namespace -> namespace '*' ident:
-    build_model('Namespace', line('$1'), ["*", unwrap('$3')]).
+    build_node('Namespace', line('$1'), ["*", unwrap('$3')]).
 Namespace -> namespace ident ident:
-    build_model('Namespace', line('$1'), [unwrap('$2'), unwrap('$3')]).
+    build_node('Namespace', line('$1'), [unwrap('$2'), unwrap('$3')]).
 
 % Definitions
 
@@ -80,9 +80,9 @@ Definition -> Service: '$1'.
 % Constants
 
 Const -> const FieldType ident '=' ConstValue Separator:
-    build_model('Constant', line('$1'), [unwrap('$3'), '$5', '$2']).
+    build_node('Constant', line('$1'), [unwrap('$3'), '$5', '$2']).
 
-ConstValue -> ident: build_model('ValueRef', line('$1'), [unwrap('$1')]).
+ConstValue -> ident: build_node('ValueRef', line('$1'), [unwrap('$1')]).
 ConstValue -> true: unwrap('$1').
 ConstValue -> false: unwrap('$1').
 ConstValue -> int: unwrap('$1').
@@ -106,7 +106,7 @@ Typedef -> typedef FieldType Annotations ident Annotations Separator:
 % Enum
 
 Enum -> enum ident '{' EnumList '}' Annotations:
-    build_model('TEnum', line('$1'), '$6', [unwrap('$2'), '$4']).
+    build_node('TEnum', line('$1'), '$6', [unwrap('$2'), '$4']).
 
 EnumList -> EnumValue Separator: ['$1'].
 EnumList -> EnumValue Separator EnumList: ['$1'|'$3'].
@@ -117,22 +117,22 @@ EnumValue -> ident Annotations: unwrap('$1').
 % Struct
 
 Struct -> struct ident '{' FieldList '}' Annotations:
-    build_model('Struct', line('$1'), '$6', [unwrap('$2'), '$4']).
+    build_node('Struct', line('$1'), '$6', [unwrap('$2'), '$4']).
 
 % Union
 
 Union -> union ident '{' FieldList '}' Annotations:
-    build_model('Union', line('$1'), '$6', [unwrap('$2'), '$4']).
+    build_node('Union', line('$1'), '$6', [unwrap('$2'), '$4']).
 
 % Exception
 
 Exception -> exception ident '{' FieldList '}' Annotations:
-    build_model('Exception', line('$1'), '$6', [unwrap('$2'), '$4']).
+    build_node('Exception', line('$1'), '$6', [unwrap('$2'), '$4']).
 
 % Service
 
 Service -> service ident Extends '{' FunctionList '}' Annotations:
-    build_model('Service', line('$1'), '$7', [unwrap('$2'), '$5', '$3']).
+    build_node('Service', line('$1'), '$7', [unwrap('$2'), '$5', '$3']).
 
 Extends -> extends ident: unwrap('$2').
 Extends -> '$empty': nil.
@@ -143,7 +143,7 @@ FunctionList -> '$empty': [].
 FunctionList -> Function FunctionList: ['$1'|'$2'].
 
 Function -> Oneway ReturnType ident '(' FieldList ')' Throws Annotations Separator:
-    build_model('Function', line('$3'), '$8', ['$1', '$2', unwrap('$3'), '$5', '$7']).
+    build_node('Function', line('$3'), '$8', ['$1', '$2', unwrap('$3'), '$5', '$7']).
 
 Oneway -> '$empty': false.
 Oneway -> oneway: true.
@@ -160,7 +160,7 @@ FieldList -> '$empty': [].
 FieldList -> Field FieldList: ['$1'|'$2'].
 
 Field -> FieldIdentifier FieldRequired FieldType ident FieldDefault Annotations Separator:
-    build_model('Field', line('$4'), '$6', ['$1', '$2', '$3', unwrap('$4'), '$5']).
+    build_node('Field', line('$4'), '$6', ['$1', '$2', '$3', unwrap('$4'), '$5']).
 
 FieldIdentifier -> int ':': unwrap('$1').
 FieldIdentifier -> '$empty': nil.
@@ -174,7 +174,7 @@ FieldDefault -> '=' ConstValue: '$2'.
 
 % Types
 
-FieldType -> ident: build_model('TypeRef', line('$1'), [unwrap('$1')]).
+FieldType -> ident: build_node('TypeRef', line('$1'), [unwrap('$1')]).
 FieldType -> BaseType: '$1'.
 FieldType -> MapType: {map, '$1'}.
 FieldType -> SetType: {set, '$1'}.
@@ -215,18 +215,18 @@ Separator -> '$empty'.
 
 Erlang code.
 
-% Construct a new model of the requested Type. Args are passed to the model's
+% Construct a new AST nodeof the requested Type. Args are passed to the node's
 % `new` function and, if provided, line number information is assigned to the
-% resulting model.
-build_model(Type, Args) when is_list(Args) ->
+% resulting node.
+build_node(Type, Args) when is_list(Args) ->
     Module = list_to_atom("Elixir.Thrift.AST." ++ atom_to_list(Type)),
     apply(Module, 'new', Args).
-build_model(Type, Line, Args) when is_integer(Line) and is_list(Args) ->
-    Model = build_model(Type, Args),
+build_node(Type, Line, Args) when is_integer(Line) and is_list(Args) ->
+    Model = build_node(Type, Args),
     maps:put(line, Line, Model).
-build_model(Type, Line, Annotations, Args)
+build_node(Type, Line, Annotations, Args)
   when is_integer(Line) and is_map(Annotations) and is_list(Args) ->
-    Model = build_model(Type, Line, Args),
+    Model = build_node(Type, Line, Args),
     maps:put(annotations, Annotations, Model).
 
 % Extract the line number from the lexer's expression tuple.

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -219,7 +219,7 @@ Erlang code.
 % `new` function and, if provided, line number information is assigned to the
 % resulting model.
 build_model(Type, Args) when is_list(Args) ->
-    Module = list_to_atom("Elixir.Thrift.Parser.Models." ++ atom_to_list(Type)),
+    Module = list_to_atom("Elixir.Thrift.AST." ++ atom_to_list(Type)),
     apply(Module, 'new', Args).
 build_model(Type, Line, Args) when is_integer(Line) and is_list(Args) ->
     Model = build_model(Type, Args),

--- a/test/thrift/parser/annotation_test.exs
+++ b/test/thrift/parser/annotation_test.exs
@@ -1,7 +1,7 @@
 defmodule Thrift.Parser.AnnotationTest do
   use ExUnit.Case, async: true
   import Thrift.Parser, only: [parse: 1]
-  alias Thrift.Parser.Models.Field
+  alias Thrift.AST.Field
 
   setup_all do
     {:ok, schema} =

--- a/test/thrift/parser/file_group_test.exs
+++ b/test/thrift/parser/file_group_test.exs
@@ -2,8 +2,8 @@ defmodule Thrift.Parser.FileGroupTest do
   use ExUnit.Case
   use ThriftTestHelpers
 
+  alias Thrift.AST.Constant
   alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.Constant
 
   test "constant module uses suitable existing name" do
     with_thrift_files([

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -6,19 +6,21 @@ defmodule Thrift.Parser.ParserTest do
 
   import Thrift.Parser, only: [parse: 1, parse: 2, parse_file: 2]
 
-  alias Thrift.Parser.Models.Constant
-  alias Thrift.Parser.Models.Exception
-  alias Thrift.Parser.Models.Field
-  alias Thrift.Parser.Models.Function
-  alias Thrift.Parser.Models.Include
-  alias Thrift.Parser.Models.Namespace
-  alias Thrift.Parser.Models.Schema
-  alias Thrift.Parser.Models.Service
-  alias Thrift.Parser.Models.Struct
-  alias Thrift.Parser.Models.TypeRef
-  alias Thrift.Parser.Models.TEnum
-  alias Thrift.Parser.Models.Union
-  alias Thrift.Parser.Models.ValueRef
+  alias Thrift.AST.{
+    Constant,
+    Exception,
+    Field,
+    Function,
+    Include,
+    Namespace,
+    Schema,
+    Service,
+    Struct,
+    TypeRef,
+    TEnum,
+    Union,
+    ValueRef,
+  }
 
   import ExUnit.CaptureIO
 

--- a/test/thrift/parser/resolver_test.exs
+++ b/test/thrift/parser/resolver_test.exs
@@ -1,14 +1,14 @@
 defmodule ResolverTest do
   use ExUnit.Case
 
-  alias Thrift.Parser.FileGroup
-  alias Thrift.Parser.Models.{
+  alias Thrift.AST.{
     Field,
     TEnum,
     Service,
     Struct,
     Union
   }
+  alias Thrift.Parser.FileGroup
 
   use ThriftTestHelpers
 


### PR DESCRIPTION
This moves the nested Models into a more distinct top-level namespace.
There aren't any functional changes here, but it prefaces future work to
better define the parsed (AST) representation of a Thrift file.