### PR TITLE
Add a .formatter.exs configuration file

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{bench,config,lib,test}/**/*.{ex,exs}"]
+]

--- a/bench/binary_protocol_bench.exs
+++ b/bench/binary_protocol_bench.exs
@@ -14,7 +14,7 @@ defmodule BinaryProtocolBenchmark do
   before_each_bench _ do
     user_options = [
       is_evil: true,
-      user_id: 1234567,
+      user_id: 1_234_567,
       number_of_hairs_on_head: 26482,
       amount_of_red: 182,
       nineties_era_color: 24345,
@@ -23,25 +23,29 @@ defmodule BinaryProtocolBenchmark do
       friends: [],
       # my_map: %{1 => "abc", 2 => "def", 3 => "asldfkjlasdkjf"},
       # blocked_user_ids: [2234, 2345, 654365, 4356, 3456, 1234, 234, 2345, 3456, 4567],
-      optional_integers: [2234, 2345, 654365, 4356, 3456, 1234, 234, 2345, 3456, 4567],
+      optional_integers: [2234, 2345, 654_365, 4356, 3456, 1234, 234, 2345, 3456, 4567]
     ]
 
-    erlang_users = for _ <- 1..1000 do
-      user(:erlang, user_options)
-    end
+    erlang_users =
+      for _ <- 1..1000 do
+        user(:erlang, user_options)
+      end
 
-    elixir_users = for _ <- 1..1000 do
+    elixir_users =
+      for _ <- 1..1000 do
+        user(:elixir, user_options)
+      end
+
+    user_binary =
       user(:elixir, user_options)
-    end
-
-    user_binary = user(:elixir, user_options)
-    |> serialize_user_elixir(convert_to_binary: true)
+      |> serialize_user_elixir(convert_to_binary: true)
 
     context = [
       elixir_users: elixir_users,
       erlang_users: erlang_users,
-      user_binary: user_binary,
+      user_binary: user_binary
     ]
+
     {:ok, context}
   end
 
@@ -49,6 +53,7 @@ defmodule BinaryProtocolBenchmark do
     for user <- bench_context[:erlang_users] do
       serialize_user_erlang(user, convert_to_binary: true)
     end
+
     :ok
   end
 
@@ -56,14 +61,16 @@ defmodule BinaryProtocolBenchmark do
     for user <- bench_context[:erlang_users] do
       serialize_user_erlang(user, convert_to_binary: false)
     end
+
     :ok
   end
 
   bench "elixir serialization (iolist_size)" do
     for user <- bench_context[:elixir_users] do
       serialize_user_elixir(user, convert_to_binary: false)
-      |> :erlang.iolist_size
+      |> :erlang.iolist_size()
     end
+
     :ok
   end
 
@@ -71,6 +78,7 @@ defmodule BinaryProtocolBenchmark do
     for user <- bench_context[:elixir_users] do
       serialize_user_elixir(user, convert_to_binary: true)
     end
+
     :ok
   end
 
@@ -78,6 +86,7 @@ defmodule BinaryProtocolBenchmark do
     for user <- bench_context[:elixir_users] do
       serialize_user_elixir(user, convert_to_binary: false)
     end
+
     :ok
   end
 
@@ -85,6 +94,7 @@ defmodule BinaryProtocolBenchmark do
     for _ <- 1..1000 do
       deserialize_user_erlang(bench_context[:user_binary])
     end
+
     :ok
   end
 
@@ -92,6 +102,7 @@ defmodule BinaryProtocolBenchmark do
     for _ <- 1..1000 do
       deserialize_user_elixir(bench_context[:user_binary])
     end
+
     :ok
   end
 end

--- a/bench/binary_protocol_bench.exs
+++ b/bench/binary_protocol_bench.exs
@@ -5,8 +5,7 @@ defmodule BinaryProtocolBenchmark do
   import ParserUtils
 
   setup_all do
-    parse_thrift(@thrift_file_path)
-    |> compile_module
+    compile_module(parse_thrift(@thrift_file_path))
 
     {:ok, :ok}
   end
@@ -36,9 +35,7 @@ defmodule BinaryProtocolBenchmark do
         user(:elixir, user_options)
       end
 
-    user_binary =
-      user(:elixir, user_options)
-      |> serialize_user_elixir(convert_to_binary: true)
+    user_binary = serialize_user_elixir(user(:elixir, user_options), convert_to_binary: true)
 
     context = [
       elixir_users: elixir_users,
@@ -67,8 +64,7 @@ defmodule BinaryProtocolBenchmark do
 
   bench "elixir serialization (iolist_size)" do
     for user <- bench_context[:elixir_users] do
-      serialize_user_elixir(user, convert_to_binary: false)
-      |> :erlang.iolist_size()
+      :erlang.iolist_size(serialize_user_elixir(user, convert_to_binary: false))
     end
 
     :ok

--- a/bench/framed_server_bench.exs
+++ b/bench/framed_server_bench.exs
@@ -29,9 +29,9 @@ defmodule FramedServerBenchmark do
 
     Application.start(:ranch)
 
-    {:ok, server_pid} = SimpleService.Binary.Framed.Server.start_link(Simple.Handler, 12345, [])
+    {:ok, _} = SimpleService.Binary.Framed.Server.start_link(Simple.Handler, 12345, [])
 
-    {:ok, erlang_server_pid} =
+    {:ok, _} =
       :thrift_socket_server.start(
         handler: ErlangHandlers,
         port: 56789,
@@ -78,23 +78,21 @@ defmodule FramedServerBenchmark do
   bench "Echoing a struct in Elixir" do
     user = bench_context[:elixir_user]
     client = bench_context[:client]
-    {:ok, user} = SimpleService.Binary.Framed.Client.echo_user(client, user)
+    {:ok, _} = SimpleService.Binary.Framed.Client.echo_user(client, user)
   end
 
   bench "Returning a boolean in Elixir" do
     client = bench_context[:client]
-    {:ok, user} = SimpleService.Binary.Framed.Client.ping(client)
+    {:ok, _} = SimpleService.Binary.Framed.Client.ping(client)
   end
 
   bench "Echoing a struct in Erlang" do
     {_client, {:ok, _u}} =
-      bench_context[:erlang_client]
-      |> :thrift_client.call(:echo_user, [bench_context[:erlang_user]])
+      :thrift_client.call(bench_context[:erlang_client], :echo_user, [bench_context[:erlang_user]])
   end
 
   bench "Returning a boolean in Erlang" do
     {_client, {:ok, true}} =
-      bench_context[:erlang_client]
-      |> :thrift_client.call(:ping, [])
+      :thrift_client.call(bench_context[:erlang_client], :ping, [])
   end
 end

--- a/bench/framed_server_bench.exs
+++ b/bench/framed_server_bench.exs
@@ -30,25 +30,29 @@ defmodule FramedServerBenchmark do
     Application.start(:ranch)
 
     {:ok, server_pid} = SimpleService.Binary.Framed.Server.start_link(Simple.Handler, 12345, [])
-    {:ok, erlang_server_pid} = :thrift_socket_server.start(handler: ErlangHandlers,
-                                                           port: 56789,
-                                                           service: :simple_service_thrift,
-                                                           framed: true,
-                                                           socket_opts: [
-                                                             recv_timeout: 15_000,
-                                                             keepalive: true])
 
-    map_value = 1..100
-    |> Enum.map(fn num -> {num, "foo#{num}"} end)
-    |> Map.new
+    {:ok, erlang_server_pid} =
+      :thrift_socket_server.start(
+        handler: ErlangHandlers,
+        port: 56789,
+        service: :simple_service_thrift,
+        framed: true,
+        socket_opts: [recv_timeout: 15_000, keepalive: true]
+      )
+
+    map_value =
+      1..100
+      |> Enum.map(fn num -> {num, "foo#{num}"} end)
+      |> Map.new()
 
     blocked_user_ids = Enum.to_list(50_000..50_150)
+
     user_options = [
       is_evil: false,
-      user_id: 2841204,
-      number_of_hairs_on_head: 1029448,
+      user_id: 2_841_204,
+      number_of_hairs_on_head: 1_029_448,
       amount_of_red: 23,
-      nineties_era_color: 381221,
+      nineties_era_color: 381_221,
       mint_gum: 24421.024,
       username: "Stinkypants",
       my_map: map_value,
@@ -60,9 +64,15 @@ defmodule FramedServerBenchmark do
     elixir_user = user(:elixir, user_options)
 
     {:ok, client} = SimpleService.Binary.Framed.Client.start_link("localhost", 12345, [])
-    {:ok, erlang_client} = :thrift_client_util.new('localhost', 56789, :simple_service_thrift, framed: true)
 
-    {:ok, elixir_user: elixir_user, erlang_user: erlang_user, client: client, erlang_client: erlang_client}
+    {:ok, erlang_client} =
+      :thrift_client_util.new('localhost', 56789, :simple_service_thrift, framed: true)
+
+    {:ok,
+     elixir_user: elixir_user,
+     erlang_user: erlang_user,
+     client: client,
+     erlang_client: erlang_client}
   end
 
   bench "Echoing a struct in Elixir" do
@@ -77,13 +87,14 @@ defmodule FramedServerBenchmark do
   end
 
   bench "Echoing a struct in Erlang" do
-    {_client, {:ok, _u}} = bench_context[:erlang_client]
-    |> :thrift_client.call(:echo_user, [bench_context[:erlang_user]])
+    {_client, {:ok, _u}} =
+      bench_context[:erlang_client]
+      |> :thrift_client.call(:echo_user, [bench_context[:erlang_user]])
   end
 
   bench "Returning a boolean in Erlang" do
-    {_client, {:ok, true}} = bench_context[:erlang_client]
-    |> :thrift_client.call(:ping, [])
+    {_client, {:ok, true}} =
+      bench_context[:erlang_client]
+      |> :thrift_client.call(:ping, [])
   end
-
 end


### PR DESCRIPTION
The only change from the default configuration is the inclusion of the
`bench/` directory to the list of inputs.

Also, apply the formatter to the `bench/*.exs` source files.