### PR TITLE
Address all of credo's "readability" issues

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -19,7 +19,7 @@
     checks: [
       {Credo.Check.Consistency.ExceptionNames},
       {Credo.Check.Consistency.LineEndings},
-      {Credo.Check.Consistency.MultiAliasImportRequireUse},
+      {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
       {Credo.Check.Consistency.SpaceAroundOperators},
       {Credo.Check.Consistency.SpaceInParentheses},
       {Credo.Check.Consistency.TabsOrSpaces},

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -9,8 +9,8 @@ defmodule Thrift.Binary.Framed.Client do
   `oneway` and `request`.
   """
   alias Thrift.Protocol.Binary
-  alias Thrift.Transport.SSL
   alias Thrift.TApplicationException
+  alias Thrift.Transport.SSL
 
   @immutable_tcp_opts [active: false, packet: 4, mode: :binary]
 

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -14,8 +14,8 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
 
   alias Thrift.{
     Protocol,
+    TApplicationException,
     Transport.SSL,
-    TApplicationException
   }
   require Logger
 

--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -5,13 +5,13 @@ defmodule Thrift.Generator do
   """
 
   alias Thrift.AST.{Constant, Schema}
-  alias Thrift.Parser.FileGroup
   alias Thrift.{
     Generator,
     Generator.ConstantGenerator,
     Generator.EnumGenerator,
     Generator.StructGenerator
   }
+  alias Thrift.Parser.FileGroup
 
   @doc """
   Returns the list of target paths that would be generated from a Thrift file.

--- a/lib/thrift/generator/behaviour.ex
+++ b/lib/thrift/generator/behaviour.ex
@@ -10,8 +10,8 @@ defmodule Thrift.Generator.Behaviour do
     Exception,
     Field,
     Struct,
-    TypeRef,
     TEnum,
+    TypeRef,
     Union,
   }
   alias Thrift.Generator.Utils

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -2,12 +2,9 @@ defmodule Thrift.Generator.Service do
   @moduledoc false
 
   alias Thrift.AST.{Field, Function, Struct}
+  alias Thrift.Generator
+  alias Thrift.Generator.StructGenerator
   alias Thrift.Parser.FileGroup
-  alias Thrift.{
-    Generator,
-    Generator.StructGenerator,
-  }
-
 
   # The response struct uses a %Field{} to represent the service function's
   # return value. Functions can return :void while fields cannot. Until we can

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -42,8 +42,8 @@ defmodule Thrift.Generator.StructBinaryProtocol do
     Exception,
     Field,
     Struct,
-    TypeRef,
     TEnum,
+    TypeRef,
     Union,
   }
   alias Thrift.Generator.Utils

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -3,8 +3,8 @@ defmodule Thrift.Generator.StructGenerator do
     Exception,
     Field,
     Struct,
-    TypeRef,
     TEnum,
+    TypeRef,
     Union,
   }
   alias Thrift.Generator.{StructBinaryProtocol, Utils}

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -6,10 +6,10 @@ defmodule Thrift.Generator.Utils do
   alias Thrift.AST.{
     Constant,
     Field,
-    Struct,
     Schema,
-    TypeRef,
+    Struct,
     TEnum,
+    TypeRef,
     ValueRef,
   }
   alias Thrift.NaN

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -12,20 +12,19 @@ defmodule Thrift.Parser.FileGroup do
   alias Thrift.Parser.{
     FileGroup,
     FileRef,
+    ParsedFile,
     Resolver,
-    ParsedFile
   }
-
   alias Thrift.AST.{
-    TEnum,
     Constant,
     Exception,
     Field,
     Namespace,
-    TypeRef,
     Schema,
     Service,
     Struct,
+    TEnum,
+    TypeRef,
     Union,
     ValueRef,
   }

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -35,10 +35,12 @@ defmodule Servers.Binary.Framed.IntegrationTest do
 
   def define_handler do
     defmodule ServerTestHandler do
-      alias Servers.Binary.Framed.IntegrationTest.ServerTest.Handler
-      alias Servers.Binary.Framed.IntegrationTest.{TestException, UserNotFound, OtherException}
       alias Servers.Binary.Framed.IntegrationTest, as: T
-      @behaviour Handler
+      alias Servers.Binary.Framed.IntegrationTest.OtherException
+      alias Servers.Binary.Framed.IntegrationTest.ServerTest
+      alias Servers.Binary.Frames.IntegrationTest.TestException
+      alias Servers.Binary.Frames.IntegrationTest.UserNotFound
+      @behaviour ServerTest.Handler
 
       def do_async(message) do
         Agent.update(:server_args, fn(_) -> message end)
@@ -70,7 +72,8 @@ defmodule Servers.Binary.Framed.IntegrationTest do
     end
   end
 
-  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.{Client, Server}
+  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Client
+  alias Servers.Binary.Framed.IntegrationTest.ServerTest.Binary.Framed.Server
   alias Thrift.TApplicationException
 
   setup_all do

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -38,8 +38,8 @@ defmodule Servers.Binary.Framed.IntegrationTest do
       alias Servers.Binary.Framed.IntegrationTest, as: T
       alias Servers.Binary.Framed.IntegrationTest.OtherException
       alias Servers.Binary.Framed.IntegrationTest.ServerTest
-      alias Servers.Binary.Frames.IntegrationTest.TestException
-      alias Servers.Binary.Frames.IntegrationTest.UserNotFound
+      alias Servers.Binary.Framed.IntegrationTest.TestException
+      alias Servers.Binary.Framed.IntegrationTest.UserNotFound
       @behaviour ServerTest.Handler
 
       def do_async(message) do

--- a/test/thrift/binary/framed/ssl_test.exs
+++ b/test/thrift/binary/framed/ssl_test.exs
@@ -102,4 +102,3 @@ defmodule Servers.Binary.Framed.SSLTest do
     get_certs()
   end
 end
-

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -104,11 +104,12 @@ defmodule Thrift.Generator.ServiceTest do
     end
   end
 
-  alias Thrift.TApplicationException
   alias Thrift.ConnectionError
+  alias Thrift.Generator.ServiceTest.SimpleService.Binary.Framed.Client
+  alias Thrift.Generator.ServiceTest.SimpleService.Binary.Framed.Server
   alias Thrift.Generator.ServiceTest.User
-  alias Thrift.Generator.ServiceTest.SimpleService.Binary.Framed.{Client, Server}
   alias Thrift.Generator.ServiceTest.UsernameTakenException
+  alias Thrift.TApplicationException
 
   defp start_server(opts \\ []) do
     {:ok, pid} = Server.start_link(ServerSpy, 0, opts)

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -16,8 +16,8 @@ defmodule Thrift.Parser.ParserTest do
     Schema,
     Service,
     Struct,
-    TypeRef,
     TEnum,
+    TypeRef,
     Union,
     ValueRef,
   }

--- a/test/thrift/parser/resolver_test.exs
+++ b/test/thrift/parser/resolver_test.exs
@@ -3,9 +3,9 @@ defmodule ResolverTest do
 
   alias Thrift.AST.{
     Field,
-    TEnum,
     Service,
     Struct,
+    TEnum,
     Union
   }
   alias Thrift.Parser.FileGroup


### PR DESCRIPTION
Also disable the `MultiAliasImportRequireUse` check.