### PR TITLE
Remove public Thrift.Parser.parse/2 function

### DIFF
--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -11,9 +11,6 @@ defmodule Thrift.Parser do
   @typedoc "A map of Thrift annotation keys to values"
   @type annotations :: %{String.t() => String.t()}
 
-  @typedoc "A schema path element"
-  @type path_element :: String.t() | atom
-
   @typedoc "Available parser options"
   @type opt ::
           {:include_paths, [Path.t()]}
@@ -34,32 +31,6 @@ defmodule Thrift.Parser do
       {:error, lexer_error1, lexer_error2} ->
         {:error, {lexer_error1, lexer_error2}}
     end
-  end
-
-  @doc """
-  Parses a Thrift document and returns a component to the caller.
-
-  The part of the Thrift document that's returned is determined by the `path`
-  parameter. It works a lot like the `Kernel.get_in/2` function, which takes a
-  map and can pull out nested pieces.
-
-  For example, this makes it easy to get to a service definition:
-
-      parse(doc, [:services, :MyService])
-
-  Will return the "MyService" service.
-  """
-  @spec parse(String.t(), [path_element, ...]) :: Thrift.AST.all()
-  def parse(doc, path) do
-    {:ok, schema} = parse(doc)
-
-    Enum.reduce(path, schema, fn
-      _part, nil ->
-        nil
-
-      part, %{} = next ->
-        Map.get(next, part)
-    end)
   end
 
   @doc """

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -4,7 +4,7 @@ defmodule Thrift.Parser.ParserTest do
   @project_root Path.expand("../..", __DIR__)
   @test_file_dir Path.join([@project_root, "tmp", "parser_test"])
 
-  import Thrift.Parser, only: [parse: 1, parse: 2, parse_file: 2]
+  import Thrift.Parser, only: [parse: 1, parse_file: 2]
 
   alias Thrift.AST.{
     Constant,
@@ -23,6 +23,20 @@ defmodule Thrift.Parser.ParserTest do
   }
 
   import ExUnit.CaptureIO
+
+  # Parse a Thrift document and returns a subcomponent to the caller.
+  @spec parse(String.t(), nonempty_list(term)) :: Thrift.AST.all()
+  defp parse(doc, path) do
+    {:ok, schema} = parse(doc)
+
+    Enum.reduce(path, schema, fn
+      _part, nil ->
+        nil
+
+      part, %{} = next ->
+        Map.get(next, part)
+    end)
+  end
 
   setup_all do
     File.rm_rf!(@test_file_dir)


### PR DESCRIPTION
This is a utility function that is only used by this module's tests, so
relocate it there.

It combines two operations: parsing the document and extracting a
subcomponent based on a list of keys (the "path").

If a parsing error occurs, the function dies instead of returning the
error, which makes this a risky function to use in a real application.
Changing the return type would fix that, but I think a better solution
is to remove this function and perhaps add just the get_in/2-style
functionality to the Thrift.AST module if a need arises.