### PR TITLE
Increase the minimum Elixir version to 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Thrift.Mixfile do
     [
       app: :thrift,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       deps: deps(),
 
       # Build Environment
@@ -62,7 +62,7 @@ defmodule Thrift.Mixfile do
 
   def application do
     [
-      applications: [:logger, :connection, :ranch, :ssl]
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
This is the oldest version we're testing in CI, and it lets us take
advantage of Elixir's application inference mechanism.