### PR TITLE
Expand the code generation documentation

### DIFF
--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -90,7 +90,10 @@ defmodule Thrift do
 
   ### Namespaces
 
-  Thrift uses the `namespace` keyword to define a language's namespace:
+  The generated modules' namespace is determined by the `:namespace` compiler
+  option, which defaults to `Thrift.Generated`. Individual `.thrift` files can
+  specify their own namespace using the `namespace` keyword, taking precedence
+  over the compiler's value.
 
   ```thrift
   namespace elixir Thrift.Test

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -51,6 +51,58 @@ defmodule Thrift do
   on-demand. By default, it uses the same project configuration as the
   compiler task above, but options can also be specified using command line
   arguments.
+
+  ### Thrift Definitions
+
+  Given some Thrift type definitions:
+
+      namespace elixir Thrift.Test
+
+      exception UserNotFound {
+        1: string message
+      }
+
+      struct User {
+        1: i64 id,
+        2: string username,
+      }
+
+      service UserService {
+        bool ping(),
+        User get(1: i64 id) throws (1: UserNotFound e),
+        bool delete(1: i64 id),
+      }
+
+  ... the generated code will be placed in the following modules under
+  `lib/thrift/`:
+
+    Definition                | Module
+    ------------------------- | -----------------------------------------------
+    `User` struct             | `Thrift.Test.User`
+    *└ binary protocol*       | `Thrift.Test.User.BinaryProtocol`
+    `UserNotFound` exception  | `Thrift.Test.UserNotFound`
+    *└ binary protocol*       | `Thrift.Test.UserNotFound.BinaryProtocol`
+    `UserService` service     | `Thrift.Test.UserService.Handler`
+    *└ binary framed client*  | `Thrift.Test.UserService.Binary.Framed.Client`
+    *└ binary framed server*  | `Thrift.Test.UserService.Binary.Framed.Server`
+
+  ### Namespaces
+
+  Thrift uses the `namespace` keyword to define a language's namespace:
+
+      namespace elixir Thrift.Test
+
+  Unfortunately, the Apache Thrift compiler will produce a warning on this line
+  because it doesn't recognize `elixir` as a supported language. While that
+  warning is benign, it can be annoying. For that reason, you can also specify
+  your Elixir namespace as a "magic" namespace comment:
+
+      #@namespace elixir Thrift.Test
+
+  This alternate syntax is [borrowed from Scrooge][scrooge-ns], which uses the
+  same trick for defining Scala namespaces.
+
+  [scrooge-ns]: https://twitter.github.io/scrooge/Namespaces.html
   """
 
   @typedoc "Thrift data types"

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -56,22 +56,24 @@ defmodule Thrift do
 
   Given some Thrift type definitions:
 
-      namespace elixir Thrift.Test
+  ```thrift
+  namespace elixir Thrift.Test
 
-      exception UserNotFound {
-        1: string message
-      }
+  exception UserNotFound {
+    1: string message
+  }
 
-      struct User {
-        1: i64 id,
-        2: string username,
-      }
+  struct User {
+    1: i64 id,
+    2: string username,
+  }
 
-      service UserService {
-        bool ping(),
-        User get(1: i64 id) throws (1: UserNotFound e),
-        bool delete(1: i64 id),
-      }
+  service UserService {
+    bool ping(),
+    User get(1: i64 id) throws (1: UserNotFound e),
+    bool delete(1: i64 id),
+  }
+  ```
 
   ... the generated code will be placed in the following modules under
   `lib/thrift/`:
@@ -90,14 +92,18 @@ defmodule Thrift do
 
   Thrift uses the `namespace` keyword to define a language's namespace:
 
-      namespace elixir Thrift.Test
+  ```thrift
+  namespace elixir Thrift.Test
+  ```
 
   Unfortunately, the Apache Thrift compiler will produce a warning on this line
   because it doesn't recognize `elixir` as a supported language. While that
   warning is benign, it can be annoying. For that reason, you can also specify
   your Elixir namespace as a "magic" namespace comment:
 
-      #@namespace elixir Thrift.Test
+  ```thrift
+  #@namespace elixir Thrift.Test
+  ```
 
   This alternate syntax is [borrowed from Scrooge][scrooge-ns], which uses the
   same trick for defining Scala namespaces.


### PR DESCRIPTION
This explains how Thrift definitions are mapped to generated modules as
well as how namespaces are specified.