### PR TITLE
Upgrade to ranch 1.6

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -79,7 +79,7 @@ defmodule Thrift.Mixfile do
 
       # Runtime
       {:connection, "~> 1.0"},
-      {:ranch, "~> 1.5"}
+      {:ranch, "~> 1.6"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
+  "ranch": {:hex, :ranch, "1.6.0", "92ac674645ec5dd23c6f0aeb9fff0aae1dd4e94a0af8407ff4d14f750a4cd7cf", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This is a minor upgrade for us because we don't use many of Ranch's
features. It's useful to upgrade now to avoid any new code being added
that might use recently deprecated features that will be removed in
Ranch 2.0.

https://ninenines.eu/docs/en/ranch/1.6/guide/migrating_from_1.5/