### PR TITLE
Document the Thrift.AST.Namespace structure

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -10,15 +10,23 @@ defmodule Thrift.AST do
   alias Thrift.Parser.{Literals, Types}
 
   defmodule Namespace do
-    @moduledoc false
-    @type t :: %Namespace{line: Parser.line(), name: atom, path: String.t()}
+    @moduledoc """
+    A namespace specifies the target module, package, etc. for a document's
+    type definitions.
 
-    @enforce_keys [:name, :path]
-    defstruct line: nil, name: nil, path: nil
+    The namespace's scope indicates the target language; a `*` indicates that
+    the namespace applies to all languages. A document can specify multiple
+    namespaces, each with its own language scope.
+    """
+
+    @type t :: %Namespace{line: Parser.line(), scope: atom, value: String.t()}
+
+    @enforce_keys [:scope, :value]
+    defstruct line: nil, scope: nil, value: nil
 
     @spec new(charlist, charlist) :: t
-    def new(name, path) do
-      %Namespace{name: atomify(name), path: List.to_string(path)}
+    def new(scope, value) do
+      %Namespace{scope: atomify(scope), value: List.to_string(value)}
     end
   end
 
@@ -416,7 +424,7 @@ defmodule Thrift.AST do
     end
 
     defp merge(schema, %Namespace{} = ns) do
-      %Schema{schema | namespaces: Map.put(schema.namespaces, ns.name, ns)}
+      %Schema{schema | namespaces: Map.put(schema.namespaces, ns.scope, ns)}
     end
 
     defp merge(schema, %Constant{} = const) do

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -118,7 +118,7 @@ defmodule Thrift.Parser.FileGroup do
 
     default_namespace =
       if file_group.opts[:namespace] do
-        %Namespace{:name => :elixir, :path => file_group.opts[:namespace]}
+        %Namespace{:scope => :elixir, :value => file_group.opts[:namespace]}
       end
 
     ns_mappings = build_ns_mappings(file_group.schemas, default_namespace)
@@ -232,7 +232,7 @@ defmodule Thrift.Parser.FileGroup do
 
       namespace = %Namespace{} ->
         namespace_parts =
-          namespace.path
+          namespace.value
           |> String.split(".")
           |> Enum.map(&Macro.camelize/1)
 

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -90,10 +90,10 @@ defmodule Thrift.Parser.ParserTest do
         [:namespaces]
       )
 
-    assert namespaces[:py] == %Namespace{line: 1, name: :py, path: "foo.bar.baz"}
-    assert namespaces[:erl] == %Namespace{line: 2, name: :erl, path: "foo_bar"}
-    assert namespaces[:*] == %Namespace{line: 3, name: :*, path: "bar.baz"}
-    assert namespaces[:elixir] == %Namespace{line: 4, name: :elixir, path: "Foo"}
+    assert namespaces[:py] == %Namespace{line: 1, scope: :py, value: "foo.bar.baz"}
+    assert namespaces[:erl] == %Namespace{line: 2, scope: :erl, value: "foo_bar"}
+    assert namespaces[:*] == %Namespace{line: 3, scope: :*, value: "bar.baz"}
+    assert namespaces[:elixir] == %Namespace{line: 4, scope: :elixir, value: "Foo"}
   end
 
   test "parsing include headers" do
@@ -916,7 +916,7 @@ defmodule Thrift.Parser.ParserTest do
       result = parse_file(context[:path], namespace: namespace)
 
       if is_map(result.ns_mappings.namespace) do
-        result.ns_mappings.namespace.path
+        result.ns_mappings.namespace.value
       end
     end
 


### PR DESCRIPTION
In the process, also rename `:name` -> `:scope` and `:path` -> `:value` to
better align the code with the "official" Thrift IDL terminology.