### PR TITLE
Transform pipelines into multiple lines

### DIFF
--- a/lib/mix/tasks/compile.thrift.ex
+++ b/lib/mix/tasks/compile.thrift.ex
@@ -169,7 +169,9 @@ defmodule Mix.Tasks.Compile.Thrift do
     header = {@manifest_vsn, package_vsn()}
 
     try do
-      manifest |> File.read!() |> :erlang.binary_to_term()
+      manifest
+      |> File.read!()
+      |> :erlang.binary_to_term()
     rescue
       _ -> []
     else

--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -87,7 +87,11 @@ defmodule Thrift.Generator do
       source = Macro.to_string(quoted)
 
       path = Path.join(output_dir, filename)
-      path |> Path.dirname() |> File.mkdir_p!()
+
+      path
+      |> Path.dirname()
+      |> File.mkdir_p!()
+
       File.write!(path, source)
 
       filename

--- a/lib/thrift/generator/enum_generator.ex
+++ b/lib/thrift/generator/enum_generator.ex
@@ -90,6 +90,9 @@ defmodule Thrift.Generator.EnumGenerator do
   end
 
   defp to_name(key) do
-    key |> to_string |> String.downcase() |> String.to_atom()
+    key
+    |> to_string()
+    |> String.downcase()
+    |> String.to_atom()
   end
 end

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -82,7 +82,10 @@ defmodule Thrift.Generator.Utils do
 
   @spec underscore(atom) :: atom
   def underscore(a) when is_atom(a) do
-    a |> Atom.to_string() |> underscore |> String.to_atom()
+    a
+    |> Atom.to_string()
+    |> underscore()
+    |> String.to_atom()
   end
 
   # NOTE
@@ -102,7 +105,10 @@ defmodule Thrift.Generator.Utils do
   defmacrop debug_optimization(expr, label) do
     if @debug_optimization do
       quote do
-        unquote(expr) |> Macro.to_string() |> IO.puts()
+        unquote(expr)
+        |> Macro.to_string()
+        |> IO.puts()
+
         IO.puts(unquote(label))
       end
     else

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -223,8 +223,15 @@ defmodule Thrift.Parser.FileGroup do
       |> Atom.to_string()
       |> String.split(".", parts: 2)
 
-    module_name = name_parts |> Enum.at(0) |> String.to_atom()
-    struct_name = name_parts |> Enum.at(1) |> initialcase
+    module_name =
+      name_parts
+      |> Enum.at(0)
+      |> String.to_atom()
+
+    struct_name =
+      name_parts
+      |> Enum.at(1)
+      |> initialcase()
 
     case file_group.ns_mappings[module_name] do
       nil ->

--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -149,7 +149,10 @@ defmodule ThriftTestCase do
   end
 
   def inspect_quoted(block) do
-    block |> Macro.to_string() |> IO.puts()
+    block
+    |> Macro.to_string()
+    |> IO.puts()
+
     block
   end
 end

--- a/test/thrift/parser/lexer_test.exs
+++ b/test/thrift/parser/lexer_test.exs
@@ -80,7 +80,12 @@ defmodule Thrift.Parser.LexerTest do
     )
 
     for keyword <- keywords do
-      value = keyword |> tokenize |> Keyword.keys() |> List.first()
+      value =
+        keyword
+        |> tokenize()
+        |> Keyword.keys()
+        |> List.first()
+
       assert value == String.to_atom(keyword)
     end
   end


### PR DESCRIPTION
I personally find this multi-line style for pipelines cleaner, and it's more consistent with a lot of other Elixir projects.