### PR TITLE
Document the AST header types (Include and Namespace)

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -2,7 +2,7 @@ defmodule Thrift.AST do
   @moduledoc """
   Thrift Abstract Syntax Tree
 
-  `Thrift.Parser` returns as a tree of these structures, starting with a
+  `Thrift.Parser` returns a tree of these structures, starting with a
   `Thrift.AST.Schema` node at the root.
 
   ## Headers

--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -2,8 +2,14 @@ defmodule Thrift.AST do
   @moduledoc """
   Thrift Abstract Syntax Tree
 
-  Parsed Thrift files are repesented as a tree of these structures, starting
-  with a `Thrift.AST.Schema` node.
+  `Thrift.Parser` returns as a tree of these structures, starting with a
+  `Thrift.AST.Schema` node at the root.
+
+  ## Headers
+
+  - `Thrift.AST.Include`
+  - `Thrift.AST.Namespace`
+
   """
 
   import Thrift.Parser.Conversions
@@ -31,8 +37,12 @@ defmodule Thrift.AST do
   end
 
   defmodule Include do
-    @moduledoc false
-    @type t :: %Include{line: Thrift.Parser.line(), path: String.t()}
+    @moduledoc """
+    An include makes another file's symbols available within this file (with a
+    prefix).
+    """
+
+    @type t :: %Include{line: Thrift.Parser.line(), path: Path.t()}
 
     @enforce_keys [:path]
     defstruct line: nil, path: nil
@@ -618,17 +628,4 @@ defmodule Thrift.AST do
       end
     end
   end
-
-  @type all ::
-          Namespace.t()
-          | Include.t()
-          | Constant.t()
-          | TEnum.t()
-          | Field.t()
-          | Exception.t()
-          | Struct.t()
-          | Union.t()
-          | Function.t()
-          | Service.t()
-          | Schema.t()
 end

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -21,7 +21,7 @@ defmodule Thrift.Parser do
   @type opts :: [opt]
 
   @doc """
-  Parses a string of Thrift IDL into its AST representation.
+  Parses a Thrift IDL string into its AST representation.
   """
   @spec parse(String.t()) :: {:ok, Thrift.AST.Schema.t()} | {:error, term}
   def parse(doc) do

--- a/lib/thrift/parser.ex
+++ b/lib/thrift/parser.ex
@@ -1,6 +1,9 @@
 defmodule Thrift.Parser do
   @moduledoc """
-  This module provides functions for parsing Thrift IDL files (`.thrift`).
+  This module provides functions for parsing [Thrift IDL][idl] files
+  (`.thrift`).
+
+  [idl]: https://thrift.apache.org/docs/idl
   """
 
   alias Thrift.Parser.{FileGroup, FileRef, ParsedFile}
@@ -9,7 +12,7 @@ defmodule Thrift.Parser do
   @type line :: pos_integer | nil
 
   @typedoc "A map of Thrift annotation keys to values"
-  @type annotations :: %{String.t() => String.t()}
+  @type annotations :: %{required(String.t()) => String.t()}
 
   @typedoc "Available parser options"
   @type opt ::
@@ -18,7 +21,7 @@ defmodule Thrift.Parser do
   @type opts :: [opt]
 
   @doc """
-  Parses a Thrift document and returns the schema that it represents.
+  Parses a string of Thrift IDL into its AST representation.
   """
   @spec parse(String.t()) :: {:ok, Thrift.AST.Schema.t()} | {:error, term}
   def parse(doc) do

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -25,7 +25,6 @@ defmodule Thrift.Parser.ParserTest do
   import ExUnit.CaptureIO
 
   # Parse a Thrift document and returns a subcomponent to the caller.
-  @spec parse(String.t(), nonempty_list(term)) :: Thrift.AST.all()
   defp parse(doc, path) do
     {:ok, schema} = parse(doc)
 


### PR DESCRIPTION
Also remove the unused `Thrift.AST.all()` type and make some small
improvements to the `Thrift.Parser` docs.