### PR TITLE
Mark private modules with `@moduledoc false`

### DIFF
--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -146,9 +146,10 @@ defmodule Thrift do
     [:bool, :i8, :i16, :i32, :i64, :binary, :double, :byte, :string]
   end
 
-  # A struct for handling IEEE-754 NaN values.
   defmodule NaN do
-    @moduledoc false
+    @moduledoc """
+    A struct for handling IEEE-754 NaN values.
+    """
     @type t :: %NaN{
             sign: 0 | 1,
             # 2^52 - 1

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -150,6 +150,7 @@ defmodule Thrift do
     @moduledoc """
     A struct for handling IEEE-754 NaN values.
     """
+
     @type t :: %NaN{
             sign: 0 | 1,
             # 2^52 - 1

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -146,11 +146,9 @@ defmodule Thrift do
     [:bool, :i8, :i16, :i32, :i64, :binary, :double, :byte, :string]
   end
 
+  # A struct for handling IEEE-754 NaN values.
   defmodule NaN do
-    @moduledoc """
-    A struct for handling IEEE-754 NaN values.
-    """
-
+    @moduledoc false
     @type t :: %NaN{
             sign: 0 | 1,
             # 2^52 - 1

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -1,13 +1,13 @@
+# A client implementation of Thrift's Binary Framed protocol.
+#
+# This client is meant to be used with a generated Thrift client. This module
+# implements framing on top of the Connection behaviour.
+#
+# This module ony adds two functions to the connection behaviour,
+# `oneway` and `request`.
 defmodule Thrift.Binary.Framed.Client do
-  @moduledoc """
-  A client implementation of Thrift's Binary Framed protocol.
+  @moduledoc false
 
-  This client is meant to be used with a generated Thrift client. This module
-  implements framing on top of the Connection behaviour.
-
-  This module ony adds two functions to the connection behaviour,
-  `oneway` and `request`.
-  """
   alias Thrift.Protocol.Binary
   alias Thrift.TApplicationException
   alias Thrift.Transport.SSL

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -1,7 +1,5 @@
 defmodule Thrift.Binary.Framed.ProtocolHandler do
-  @moduledoc """
-  A GenServer that accepts connections on a server and processes the thrift messages.
-  """
+  @moduledoc false
 
   @default_timeout 20_000
   @ssl_header_byte 0x16

--- a/lib/thrift/generator/behaviour.ex
+++ b/lib/thrift/generator/behaviour.ex
@@ -1,11 +1,9 @@
+# Takes a thrift service definition and creates a behavoiur module for users
+# to implement. Thrift types are converted into Elixir typespecs that are
+# equivalent to their thrift counterparts.
 defmodule Thrift.Generator.Behaviour do
-  @moduledoc """
-  A generator for a handler module's behaviour.
+  @moduledoc false
 
-  Takes a thrift service definition and creates a behavoiur module for users
-  to implement. Thrift types are converted into Elixir typespecs that are
-  equivalent to their thrift counterparts.
-  """
   alias Thrift.AST.{
     Exception,
     Field,

--- a/lib/thrift/generator/enum_generator.ex
+++ b/lib/thrift/generator/enum_generator.ex
@@ -1,4 +1,6 @@
 defmodule Thrift.Generator.EnumGenerator do
+  @moduledoc false
+
   def generate(name, enum) do
     macro_defs =
       Enum.map(enum.values, fn {key, value} ->

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -1,42 +1,41 @@
+# This module implements code generation of binary protocol deserialization.
+#
+# Consider a Thrift struct.
+#
+#   struct MyStruct {
+#     1: i32 num;
+#     2: list<i32> nums;
+#     3: map<string, OtherStruct> structs;
+#   }
+#
+# You could visual this as a tree of types like the following.
+#
+#   struct (MyStruct)
+#   ├ i32
+#   ├ list
+#   │ └ i32
+#   └ map
+#     ├ key
+#     │ └ string
+#     └ value
+#       └ struct (OtherStruct)
+#
+# We care about the edges of this graph. This module needs to know how to
+# implement deserializers for each transition from one type to another.
+#
+# - struct -> i32
+# - struct -> list
+# - list -> i32
+# - struct -> map
+# - map key -> string
+# - map value -> struct
+#
+# For the struct at the root of the graph, we generate a deserializer for each
+# field. Other structs are leaf nodes in the graph. Rather than generating the
+# deserialization logic inline, we make a call to the module we expect to have
+# been generated for that struct.
 defmodule Thrift.Generator.StructBinaryProtocol do
-  @moduledoc """
-  This module implements code generation of binary protocol deserialization.
-
-  Consider a Thrift struct.
-
-    struct MyStruct {
-      1: i32 num;
-      2: list<i32> nums;
-      3: map<string, OtherStruct> structs;
-    }
-
-  You could visual this as a tree of types like the following.
-
-    struct (MyStruct)
-    ├ i32
-    ├ list
-    │ └ i32
-    └ map
-      ├ key
-      │ └ string
-      └ value
-        └ struct (OtherStruct)
-
-  We care about the edges of this graph. This module needs to know how to
-  implement deserializers for each transition from one type to another.
-
-  - struct -> i32
-  - struct -> list
-  - list -> i32
-  - struct -> map
-  - map key -> string
-  - map value -> struct
-
-  For the struct at the root of the graph, we generate a deserializer for each
-  field. Other structs are leaf nodes in the graph. Rather than generating the
-  deserialization logic inline, we make a call to the module we expect to have
-  been generated for that struct.
-  """
+  @moduledoc false
 
   alias Thrift.AST.{
     Exception,

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -1,4 +1,6 @@
 defmodule Thrift.Generator.StructGenerator do
+  @moduledoc false
+
   alias Thrift.AST.{
     Exception,
     Field,

--- a/lib/thrift/generator/utils.ex
+++ b/lib/thrift/generator/utils.ex
@@ -1,7 +1,5 @@
 defmodule Thrift.Generator.Utils do
-  @moduledoc """
-  Collection of utilities for working with generated code.
-  """
+  @moduledoc false
 
   alias Thrift.AST.{
     Constant,

--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -1,12 +1,5 @@
 defmodule Thrift.Parser.FileGroup do
-  @moduledoc """
-  Represents a group of parsed files.
-
-  When you parse a file, it might include other thrift files. These files are
-  in turn accumulated and parsed and added to this module. Additionally, this
-  module allows resolution of the names of Structs / Enums / Unions etc across
-  files.
-  """
+  @moduledoc false
 
   alias Thrift.Parser
 


### PR DESCRIPTION
I don't think any of these modules are intended to be public API, so it
removes their formal @moduledoc documentation. I retained some of that
text as comments because there's some useful information in there.