### PR TITLE
Ignore the .elixir_ls directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build
+/.elixir_ls
 /cover
 /deps
 /doc


### PR DESCRIPTION
This is used by the Elixir Language Server and shouldn't be stored in
source control.