### PR TITLE
Increase the required Elixir version to 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ branches:
 
 matrix:
   include:
-    - elixir: 1.4
-      otp_release: 19.3
     - elixir: 1.5
       otp_release: 19.3
     - elixir: 1.6

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -61,6 +61,7 @@ defmodule Thrift.Binary.Framed.Client do
   require Logger
   use Connection
 
+  @impl Connection
   def init({host, port, opts}) do
     tcp_opts = Keyword.get(opts, :tcp_opts, [])
     ssl_opts = Keyword.get(opts, :ssl_opts, [])
@@ -107,7 +108,7 @@ defmodule Thrift.Binary.Framed.Client do
   """
   def close(conn), do: Connection.call(conn, :close)
 
-  @doc false
+  @impl Connection
   def connect(_info, %{sock: nil, host: host, port: port, tcp_opts: opts, timeout: timeout} = s) do
     opts =
       opts
@@ -128,7 +129,7 @@ defmodule Thrift.Binary.Framed.Client do
     end
   end
 
-  @doc false
+  @impl Connection
   def disconnect(info, %{sock: {transport, sock}}) do
     :ok = transport.close(sock)
 
@@ -236,10 +237,12 @@ defmodule Thrift.Binary.Framed.Client do
     end
   end
 
+  @impl Connection
   def handle_call(:close, from, s) do
     {:disconnect, {:close, from}, s}
   end
 
+  @impl Connection
   def handle_cast(_, %{sock: nil} = s) do
     {:noreply, s}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Thrift.Mixfile do
     [
       app: :thrift,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       deps: deps(),
 
       # Build Environment

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -43,29 +43,37 @@ defmodule Servers.Binary.Framed.IntegrationTest do
       alias Servers.Binary.Framed.IntegrationTest.UserNotFound
       @behaviour ServerTest.Handler
 
+      @impl ServerTest.Handler
       def do_async(message) do
         Agent.update(:server_args, fn _ -> message end)
       end
 
+      @impl ServerTest.Handler
       def ping, do: true
 
+      @impl ServerTest.Handler
       def checked_exception do
         raise T.TestException, message: "Oh noes!", code: 400
       end
 
+      @impl ServerTest.Handler
       def server_exception do
         raise "This wasn't supposed to happen"
       end
 
+      @impl ServerTest.Handler
       def echo_struct(id_and_name), do: id_and_name
 
+      @impl ServerTest.Handler
       def returns_nothing, do: nil
 
+      @impl ServerTest.Handler
       def multiple_exceptions(1), do: raise(TestException, message: "BOOM", code: 124)
       def multiple_exceptions(2), do: raise(UserNotFound, message: "Not here!")
       def multiple_exceptions(3), do: raise(OtherException, message: "This is the other")
       def multiple_exceptions(_), do: true
 
+      @impl ServerTest.Handler
       def my_camel_cased_function(user_name) do
         Agent.update(:server_args, fn _ -> user_name end)
         2421

--- a/test/thrift/binary/framed/ssl_test.exs
+++ b/test/thrift/binary/framed/ssl_test.exs
@@ -14,6 +14,8 @@ defmodule Servers.Binary.Framed.SSLTest do
     defmodule SSLTestHandler do
       alias Servers.Binary.Framed.SSLTest.SSLTest.Handler
       @behaviour Handler
+
+      @impl Handler
       def ping, do: true
     end
   end


### PR DESCRIPTION
This lets us use `@impl` to formally declare functions that implement
behaviour callbacks (updated here). It also gives us support for
`child_spec/1`-based supervisors (to do).

Elixir 1.5 is the last version that supports OTP 18. Dropping support
for Elixir 1.4 also lets us reduce one row from our testing matrix.