### PR TITLE
Switch to Dialyzer's :app_tree deps mode

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Thrift.Mixfile do
 
       # Dialyzer
       dialyzer: [
-        plt_add_deps: :transitive,
+        plt_add_deps: :app_tree,
         plt_add_apps: [:mix],
         ignore_warnings: ".dialyzerignore"
       ],


### PR DESCRIPTION
We don't need to recursively walk through the entire dependency tree to
discover our Dialyzer dependencies. We can just use the OTP application
dependencies.

This produces a smaller PLT set and results in faster analysis.