### PR TITLE
Add module documentation for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,6 @@ To start a server with UserServiceHandler as the callback module:
 
 ...and your server is up and running. RPC calls to the server are delegated to UserServiceHandler.
 
-Like the client, the server takes several options. They are:
-
-Name           |  Type | Description
----------------|-------|-------------
-`worker_count`   | positive integer | The number of acceptor workers available to take requests
-`name`  | atom | (Optional) The name of the server. The server's pid becomes registered to this name. If not specified, the handler module's name is used.
-`max_restarts` | non negative integer | The number of times to restart (see the next option)
-`max_seconds`  | non negative integer | The number of seconds. This is used by the supervisor to determine when to crash. If a server restarts `max_restarts` times in `max_seconds` then the supervisor crashes.
-
 The server defines a Supervisor, which can be added to your application's supervision tree. When adding the server to your applications supervision tree, use the `supervisor` function rather than the `worker` function.
 
 ## Using the binary protocol directly

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -140,6 +140,42 @@ defmodule Thrift do
   [naming], so `getUser` becomes `get_user`.
 
   [naming]: http://elixir-lang.org/docs/stable/elixir/naming-conventions.html
+
+  ## Servers
+
+  Thrift servers are a little more involved because you need to create a module
+  to handle the work. Fortunately, a `Behaviour` is generated for each server
+  (complete with typespecs). Just use the `@behavior` module attribute, and the
+  compiler will tell you about any functions you might have missed.
+
+      defmodule UserServiceHandler do
+        @behaviour Thrift.Test.UserService.Handler
+
+        def ping, do: true
+
+        def get_user(user_id) do
+          case Backend.find_user_by_id(user_id) do
+            {:ok, user} ->
+              user
+            {:error, _} ->
+              raise Thrift.Test.UserNotFound.exception message: "could not find user with id #{user_id}"
+          end
+        end
+
+        def delete(user_id) do
+          Backend.delete_user(user_id) == :ok
+        end
+      end
+
+  To start the server:
+
+      {:ok, pid} = Thrift.Test.UserService.Binary.Framed.Server.start_link(UserServiceHandler, 2345, [])
+
+  ... and all RPC calls will be delegated to `UserServiceHandler`.
+
+  The server defines a Supervisor, which can be added to your application's
+  supervision tree. When adding the server to your applications supervision
+  tree, use the `supervisor` function rather than the `worker` function.
   """
 
   @typedoc "Thrift data types"

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -145,7 +145,7 @@ defmodule Thrift do
 
   Thrift servers are a little more involved because you need to create a module
   to handle the work. Fortunately, a `Behaviour` is generated for each server
-  (complete with typespecs). Just use the `@behavior` module attribute, and the
+  (complete with typespecs). Use the `@behaviour` module attribute, and the
   compiler will tell you about any functions you might have missed.
 
       defmodule UserServiceHandler do

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -112,8 +112,7 @@ defmodule Thrift.Binary.Framed.Client do
       connections
     - `:configure`: A 0-arity function to provide additional SSL options at
       runtime
-    - Additional `Thrift.Transport.SSL.option` values specifying other
-      standard [`:ssl` options](http://erlang.org/doc/man/ssl.html)
+    - Additional `:ssl.ssl_option/0` values specifying other `:ssl` options
 
   `gen_server_opts`: A keyword list of options for the GenServer:
 

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -29,12 +29,6 @@ defmodule Thrift.Binary.Framed.Server do
   registered under this name. If not specified, the handler module's name
   is used.
 
-  `:max_restarts`: The number of times to restart (see `:max_seconds`).
-
-  `:max_seconds`: The number of seconds. This is used by the supervisor to
-  determine when to crash. If a server restarts max_restarts times in
-  `:max_seconds` then the supervisor crashes.
-
   `tcp_opts`: A keyword list that controls how the underlying connection is
   handled. All options are sent directly to `:ranch_tcp`.
 

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -23,7 +23,7 @@ defmodule Thrift.Binary.Framed.Server do
 
   The following server options can be specified:
 
-  `:worker_count`: The number of acceptor workers used to take requests.
+  `:worker_count`: The number of acceptor workers to accept on the socket.
 
   `:name`: (Optional) The name of the server. The server's pid becomes
   registered under this name. If not specified, the handler module's name
@@ -46,8 +46,7 @@ defmodule Thrift.Binary.Framed.Server do
     connections
   - `:configure`: A 0-arity function to provide additional SSL options at
     runtime
-  - Additional `t:Thrift.Transport.SSL.option/0` values specifying other
-    standard [`:ssl` options](http://erlang.org/doc/man/ssl.html)
+  - Additional `:ssl.ssl_option/0` values specifying other `:ssl` options
 
   `transport_opts` can be used to specify any additional options to pass
   to `:ranch.child_spec/6`.

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,8 @@ defmodule Thrift.Mixfile do
         source_url: @project_url,
         groups_for_modules: [
           "Abstract Syntax Tree": ~r"Thrift.AST.*",
-          Clients: ["Thrift.Binary.Framed.Client"]
+          Clients: ["Thrift.Binary.Framed.Client"],
+          Servers: ["Thrift.Binary.Framed.Server"]
         ]
       ]
     ]


### PR DESCRIPTION
This adds some high-level documentation to the `Thrift` module and
detailed documentation to `Thrift.Binary.Framed.Server`.