### PR TITLE
Fix up some dialyzer warnings

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -21,7 +21,7 @@ defmodule Thrift.AST do
   """
 
   import Thrift.Parser.Conversions
-  alias Thrift.Parser.{Literals, Types}
+  alias Thrift.Parser.{FileGroup, Literals, Types}
 
   defmodule Namespace do
     @moduledoc """

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -51,8 +51,8 @@ defmodule Thrift.Binary.Framed.Client do
     @type t :: %State{
             host: String.t(),
             port: 1..65_535,
-            tcp_opts: [Client.tcp_option()],
-            ssl_opts: [Client.ssl_option()],
+            tcp_opts: [Thrift.Binary.Framed.Client.tcp_option()],
+            ssl_opts: [SSL.option()],
             timeout: integer,
             sock: {:gen_tcp, :gen_tcp.socket()} | {:ssl, :ssl.sslsocket()},
             seq_id: integer
@@ -112,7 +112,7 @@ defmodule Thrift.Binary.Framed.Client do
       connections
     - `:configure`: A 0-arity function to provide additional SSL options at
       runtime
-    - Additional `Thrift.Transport.SSL.option` values specifying other
+    - Additional `t:Thrift.Transport.SSL.option/0` values specifying other
       standard [`:ssl` options](http://erlang.org/doc/man/ssl.html)
 
   `gen_server_opts`: A keyword list of options for the GenServer:

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -66,11 +66,11 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
       {:error, closed} when closed in [:closed, :econnreset, :timeout] ->
         :ok = transport.close(socket)
 
-      {:error, reason} ->
+      {:error, reason} = error ->
         # :ssl.format_error handles posix errors as well as ssl errors
         Logger.info(fn ->
           "#{inspect(handler_module)} (#{inspect(self())}) connection error: #{
-            :ssl.format_error(reason)
+            :ssl.format_error(error)
           } (#{inspect(reason)})"
         end)
 

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -40,6 +40,7 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
     {:ok, pid}
   end
 
+  @dialyzer {:nowarn_function, init: 7}
   @spec init(reference, port, :ranch_tcp, module, module, :ranch_tcp.opts(), [SSL.option()]) ::
           :ok | no_return
   def init(ref, socket, :ranch_tcp = transport, server_module, handler_module, tcp_opts, ssl_opts) do
@@ -66,11 +67,11 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
       {:error, closed} when closed in [:closed, :econnreset, :timeout] ->
         :ok = transport.close(socket)
 
-      {:error, reason} = error ->
+      {:error, reason} ->
         # :ssl.format_error handles posix errors as well as ssl errors
         Logger.info(fn ->
           "#{inspect(handler_module)} (#{inspect(self())}) connection error: #{
-            :ssl.format_error(error)
+            :ssl.format_error(reason)
           } (#{inspect(reason)})"
         end)
 

--- a/lib/thrift/transport/ssl.ex
+++ b/lib/thrift/transport/ssl.ex
@@ -20,10 +20,10 @@ defmodule Thrift.Transport.SSL do
 
   @type configure :: {module, function, list} | (() -> {:ok, [option]} | {:error, Exception.t()})
   @type option ::
-          :ssl.ssloption() | {:enabled, boolean} | {:optional, boolean} | {:configure, configure}
+          :ssl.ssl_option() | {:enabled, boolean} | {:optional, boolean} | {:configure, configure}
 
   @spec configuration([option]) ::
-          {:required | :optional, [:ssl.ssloption()]} | nil | {:error, Exception.t()}
+          {:required | :optional, [:ssl.ssl_option()]} | nil | {:error, Exception.t()}
   def configuration(opts) do
     case Keyword.pop(opts, :enabled, false) do
       {true, opts} ->


### PR DESCRIPTION
- `:ssl.ssloption()` -> `:ssl.ssl_option()`
- Fully qualify some types