### PR TITLE
Rework the way we handle leex/yecc errors

### DIFF
--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -88,12 +88,8 @@ defmodule Thrift.FileParseError do
   end
 
   # display the line number if we get it
-  defp format_error({line_no, :thrift_parser, errors}) do
-    "on line #{line_no}: #{errors}"
-  end
-
-  defp format_error({{line_no, :thrift_lexer, errors}, _}) do
-    "on line #{line_no}: #{inspect(errors)}"
+  defp format_error({line_no, message}) do
+    "on line #{line_no}: #{message}"
   end
 
   defp format_error(error) do

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -93,8 +93,7 @@ process_chars([$\\,C|Chars])    -> [C|process_chars(Chars)];
 process_chars([C|Chars])        -> [C|process_chars(Chars)];
 process_chars([])               -> [].
 
-reserved_keyword_error(Keyword, Line) ->
+reserved_keyword_error(Keyword, _Line) ->
     Message = io_lib:format(
-      "line ~B: cannot use reserved language keyword \"~s\"", [Line, Keyword]),
-    Exception = 'Elixir.RuntimeError':exception(list_to_binary(Message)),
-    erlang:error(Exception).
+      "cannot use reserved language keyword \"~s\"", [Keyword]),
+    {error, Message}.

--- a/test/thrift/parser/parse_error_test.exs
+++ b/test/thrift/parser/parse_error_test.exs
@@ -55,7 +55,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     /8
     """
 
-    assert {:error, _} = parse(contents)
+    assert {:error, {2, _}} = parse(contents)
 
     path = Path.join(@test_file_dir, "lexer_error.thrift")
     File.write!(path, contents)

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -877,15 +877,8 @@ defmodule Thrift.Parser.ParserTest do
   end
 
   test "names cannot override built-in keywords" do
-    thrift = """
-    struct continue {}
-    """
-
-    expected_error = "line 1: cannot use reserved language keyword \"continue\""
-
-    assert_raise RuntimeError, expected_error, fn ->
-      parse(thrift)
-    end
+    assert {:error, {1, ~S(cannot use reserved language keyword "continue")}} ==
+             parse("struct continue {}")
   end
 
   test "names can be reserved keywords if they have a different case" do


### PR DESCRIPTION
We previously returned the low-level leex and yecc errors pretty much
verbatim, relying on our `FileParseError` exception module to perform any
last-minute formatting.

This change performs parse error formatting directly in `Parser.parse/2`,
calling `:thrift_lexer.format_error/1` or `:thrift_parser.format_error/`1 as
appropriate. The error result is now always `{:error, {line, message}}`.

Also, `reserved_keyword_error/2` used to raise a runtime exception. It now
returns a leex-compatible error result so that it's no longer a special
case. This was also tripping up dialyzer because the lexer pass isn't
annotated as `no_return()`.