### PR TITLE
Always set `max_restarts: 0`

### DIFF
--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -10,8 +10,6 @@ defmodule Thrift.Binary.Framed.Server do
   @type server_option ::
           {:worker_count, pos_integer}
           | {:name, atom}
-          | {:max_restarts, non_neg_integer}
-          | {:max_seconds, non_neg_integer}
           | {:tcp_opts, :ranch_tcp.opts()}
           | {:ssl_opts, [Thrift.Transport.SSL.option()]}
           | {:transport_opts, :ranch.opts()}
@@ -48,8 +46,6 @@ defmodule Thrift.Binary.Framed.Server do
   @spec start_link(module, port :: 1..65_535, module, [server_option]) :: GenServer.on_start()
   def start_link(server_module, port, handler_module, opts) do
     name = Keyword.get(opts, :name, handler_module)
-    max_restarts = Keyword.get(opts, :max_restarts, 10)
-    max_seconds = Keyword.get(opts, :max_seconds, 5)
     worker_count = Keyword.get(opts, :worker_count, 1)
     tcp_opts = Keyword.get(opts, :tcp_opts, [])
     ssl_opts = Keyword.get(opts, :ssl_opts, [])
@@ -72,8 +68,7 @@ defmodule Thrift.Binary.Framed.Server do
     Supervisor.start_link(
       [listener],
       strategy: :one_for_one,
-      max_restarts: max_restarts,
-      max_seconds: max_seconds
+      max_restarts: 0
     )
   end
 


### PR DESCRIPTION
Instead, allow the parent supervisor to handle these things. The
server's supervisor should remain hidden from the user.