### PR TITLE
Allow annotation after field type

### DIFF
--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -159,8 +159,8 @@ Throws -> throws '(' FieldList ')': '$3'.
 FieldList -> '$empty': [].
 FieldList -> Field FieldList: ['$1'|'$2'].
 
-Field -> FieldIdentifier FieldRequired FieldType ident FieldDefault Annotations Separator:
-    build_node('Field', line('$4'), '$6', ['$1', '$2', '$3', unwrap('$4'), '$5']).
+Field -> FieldIdentifier FieldRequired FieldType Annotations ident FieldDefault Annotations Separator:
+    build_node('Field', line('$5'), '$7', ['$1', '$2', '$3', unwrap('$5'), '$6']).
 
 FieldIdentifier -> int ':': unwrap('$1').
 FieldIdentifier -> '$empty': nil.
@@ -190,8 +190,8 @@ BaseType -> double: double.
 BaseType -> string: string.
 BaseType -> binary: binary.
 
-MapType -> map '<' FieldType ',' FieldType '>': {'$3', '$5'}.
-SetType -> set '<' FieldType '>': '$3'.
+MapType -> map '<' FieldType Annotations ',' FieldType Annotations '>': {'$3', '$6'}.
+SetType -> set '<' FieldType Annotations '>': '$3'.
 ListType -> list '<' FieldType Annotations '>': '$3'.
 
 % Annotations

--- a/test/fixtures/app/thrift/AnnotationTest.thrift
+++ b/test/fixtures/app/thrift/AnnotationTest.thrift
@@ -33,11 +33,13 @@ struct foo {
 
 exception foo_error {
   1: i32 error_code ( foo="bar" )
-  2: string error_msg
+  2: string (foo="bar") error_msg
 } (foo = "bar")
 
 typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
 typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+typedef map< string ( unicode.encoding = "UTF-16" ), double ( cpp.fixed_point = "16" ) > tiny_float_map
+typedef set< double (cpp.fixed_point = "16")> (foo="bar") tiny_float_set
 
 enum weekdays {
   SUNDAY ( weekend = "yes" ),


### PR DESCRIPTION
Other thrift libraries allow annotations in a few more places. Add support for these in schemas but do not add to the AST.