### PR TITLE
Support cpp_include

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -8,6 +8,7 @@ defmodule Thrift.AST do
   ## Headers
 
   - `Thrift.AST.Include`
+  - `Thrift.AST.CppInclude`
   - `Thrift.AST.Namespace`
 
   ## Definitions
@@ -58,6 +59,22 @@ defmodule Thrift.AST do
     @spec new(charlist) :: t
     def new(path) do
       %Include{path: List.to_string(path)}
+    end
+  end
+
+  defmodule CppInclude do
+    @moduledoc """
+    A C++ include adds a custom C++ include to the output C++ code.
+    """
+
+    @type t :: %CppInclude{line: Thrift.Parser.line(), path: Path.t()}
+
+    @enforce_keys [:path]
+    defstruct line: nil, path: nil
+
+    @spec new(charlist) :: t
+    def new(path) do
+      %CppInclude{path: List.to_string(path)}
     end
   end
 
@@ -406,6 +423,7 @@ defmodule Thrift.AST do
             enums: %{String.t() => TEnum.t()},
             unions: %{String.t() => Union.t()},
             includes: [Include.t()],
+            cpp_includes: [CppInclude.t()],
             constants: %{String.t() => Literals.t()},
             exceptions: %{String.t() => Exception.t()},
             typedefs: %{String.t() => Types.t()},
@@ -419,6 +437,7 @@ defmodule Thrift.AST do
               enums: %{},
               unions: %{},
               includes: [],
+              cpp_includes: [],
               constants: %{},
               exceptions: %{},
               typedefs: %{},
@@ -448,6 +467,10 @@ defmodule Thrift.AST do
     @spec merge(t, header | definition) :: t
     defp merge(schema, %Include{} = inc) do
       %Schema{schema | includes: [inc | schema.includes]}
+    end
+
+    defp merge(schema, %CppInclude{} = cpp_inc) do
+      %Schema{schema | cpp_includes: [cpp_inc | schema.cpp_includes]}
     end
 
     defp merge(schema, %Namespace{} = ns) do

--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -30,7 +30,7 @@ BOOLEAN         = true|false
 
 IDENTIFIER      = [a-zA-Z_](\.[a-zA-Z_0-9]|[a-zA-Z_0-9])*
 
-KEYWORDS1       = namespace|include
+KEYWORDS1       = namespace|include|cpp_include
 KEYWORDS2       = typedef|enum|union|struct|exception
 KEYWORDS3       = void|bool|byte|i8|i16|i32|i64|double|string|binary|list|map|set
 KEYWORDS4       = const|oneway|extends|throws|service|required|optional

--- a/src/thrift_parser.yrl
+++ b/src/thrift_parser.yrl
@@ -16,7 +16,7 @@ Header
 Nonterminals
     Schema File
     Headers Header
-    Include Namespace
+    Include CppInclude Namespace
     Definitions Definition
     Typedef Struct Union Exception
     Const ConstValue ConstList ConstMap
@@ -31,7 +31,7 @@ Nonterminals
 Terminals
     '*' '{' '}' '[' ']' '(' ')' '=' '>' '<' ',' ':' ';'
     file
-    include namespace
+    include cpp_include namespace
     int ident
     bool byte i8 i16 i32 i64 double string binary list map set
     true false
@@ -54,10 +54,14 @@ Headers -> '$empty': [].
 Headers -> Header Headers: ['$1'|'$2'].
 
 Header -> Include: '$1'.
+Header -> CppInclude: '$1'.
 Header -> Namespace: '$1'.
 
 Include -> include string:
     build_node('Include', line('$1'), [unwrap('$2')]).
+
+CppInclude -> cpp_include string:
+    build_node('CppInclude', line('$1'), [unwrap('$2')]).
 
 Namespace -> namespace '*' ident:
     build_node('Namespace', line('$1'), ["*", unwrap('$3')]).

--- a/test/thrift/parser/lexer_test.exs
+++ b/test/thrift/parser/lexer_test.exs
@@ -73,7 +73,7 @@ defmodule Thrift.Parser.LexerTest do
 
   test "keywords" do
     keywords = ~w(
-      namespace include
+      namespace include cpp_include
       typedef enum struct union exception
       void bool byte i8 i16 i64 double string binary list map set
       const oneway extends throws service required optional

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -8,6 +8,7 @@ defmodule Thrift.Parser.ParserTest do
 
   alias Thrift.AST.{
     Constant,
+    CppInclude,
     Exception,
     Field,
     Function,
@@ -108,6 +109,22 @@ defmodule Thrift.Parser.ParserTest do
     assert includes == [
              %Include{line: 1, path: "foo.thrift"},
              %Include{line: 2, path: "bar.thrift"}
+           ]
+  end
+
+  test "parsing cpp_include headers" do
+    cpp_includes =
+      parse(
+        """
+        cpp_include "foo.h"
+        cpp_include "bar.h"
+        """,
+        [:cpp_includes]
+      )
+
+    assert cpp_includes == [
+             %CppInclude{line: 1, path: "foo.h"},
+             %CppInclude{line: 2, path: "bar.h"}
            ]
   end
 

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -118,13 +118,15 @@ defmodule Thrift.Parser.ParserTest do
         """
         cpp_include "foo.h"
         cpp_include "bar.h"
+        cpp_include "baz/qux.h"
         """,
         [:cpp_includes]
       )
 
     assert cpp_includes == [
              %CppInclude{line: 1, path: "foo.h"},
-             %CppInclude{line: 2, path: "bar.h"}
+             %CppInclude{line: 2, path: "bar.h"},
+             %CppInclude{line: 3, path: "baz/qux.h"}
            ]
   end
 


### PR DESCRIPTION
Thrift schemas may include cpp_include to include C++ files, add support in the parser.