### PR TITLE
Support empty unix comment

### DIFF
--- a/src/thrift_lexer.xrl
+++ b/src/thrift_lexer.xrl
@@ -17,9 +17,8 @@ Definitions.
 WHITESPACE      = [\s\t\r\n]+
 COMMENT         = //[^\n]*
 CCOMMENT        = /\*/*([^*/]|[^*]/|\*[^/])*\**\*/
-NSCOMMENT       = #@namespace
-UNIXCOMMENT     = #[^@][^\n]*
-COMMENTS        = {COMMENT}|{CCOMMENT}|{UNIXCOMMENT}
+COMMENTS        = {COMMENT}|{CCOMMENT}
+UNIXCOMMENT     = #[^\n]*
 
 INT             = [+-]?[0-9]+
 HEX             = [+-]?0x[0-9A-Fa-f]+
@@ -55,9 +54,9 @@ Rules.
 
 {WHITESPACE}    : skip_token.
 {COMMENTS}      : skip_token.
+{UNIXCOMMENT}   : process_unix_comment(TokenChars, TokenLine).
 
 __file__        : {token, {file, TokenLine}}.
-{NSCOMMENT}     : {token, {namespace, TokenLine}}.
 {PUNCTUATOR}    : {token, {list_to_atom(TokenChars), TokenLine}}.
 {KEYWORD}       : {token, {list_to_atom(TokenChars), TokenLine}}.
 
@@ -72,6 +71,9 @@ __file__        : {token, {file, TokenLine}}.
 {IDENTIFIER}    : {token, {ident, TokenLine, TokenChars}}.
 
 Erlang code.
+
+process_unix_comment("#@namespace" ++ Rest, Line) -> {token, {namespace, Line}, Rest};
+process_unix_comment("#" ++ _Rest, _Line)         -> skip_token.
 
 hex_to_integer([$+|Chars]) ->  hex_to_integer(Chars);
 hex_to_integer([$-|Chars]) -> -hex_to_integer(Chars);

--- a/test/thrift/parser/lexer_test.exs
+++ b/test/thrift/parser/lexer_test.exs
@@ -94,6 +94,10 @@ defmodule Thrift.Parser.LexerTest do
     assert tokenize("#@namespace") == [namespace: 1]
   end
 
+  test "empty unix comment" do
+    assert tokenize("#\ntrue") == [true: 2]
+  end
+
   test "boolean literals" do
     assert tokenize("true") == [true: 1]
     assert tokenize("false") == [false: 1]


### PR DESCRIPTION
When adding support for custom namespace via unix comments we introduced an edge case for the empty unix comment where the parse include the next line in the comment. Add processing to handle this case.