### PR TITLE
Fix missing struct key in AST.TypeRef

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -316,7 +316,7 @@ defmodule Thrift.AST do
     @type t :: %TypeRef{line: Thrift.Parser.line(), referenced_type: atom}
 
     @enforce_keys [:referenced_type]
-    defstruct line: nil, referenced_type: nil
+    defstruct line: nil, name: nil, referenced_type: nil
 
     @spec new(charlist) :: t
     def new(referenced_type) do


### PR DESCRIPTION
I was inspecting some of these `TypeRef` structs and noticed they were appearing like this:
```elixir
%{
  __struct__: Thrift.AST.TypeRef,
  line: 4,
  name: :"includes.AnotherInteger",
  referenced_type: :"includes.shared.MyInteger"
}
```
instead of
```elixir
%Thrift.AST.TypeRef{
  line: 4,
  name: :"includes.AnotherInteger",
  referenced_type: :"includes.shared.MyInteger"
}
```
This fixes it - they were missing the `:name` key in their struct definition