### PR TITLE
Fix typedefs defined as references to another typedef

### DIFF
--- a/test/thrift/generator/models_test.exs
+++ b/test/thrift/generator/models_test.exs
@@ -185,14 +185,20 @@ defmodule Thrift.Generator.ModelsTest do
                contents: """
                include "shared.thrift"
 
+               typedef shared.MyInteger AnotherInteger
+
                struct StructWithIncludedNum {
                  1: optional shared.MyInteger num = 5;
+                 2: optional AnotherInteger count = 3;
+                 3: optional list<AnotherInteger> items = [1, 2, 3];
                }
                """
 
   thrift_test "includes" do
     struct = %StructWithIncludedNum{}
     assert struct.num == 5
+    assert struct.count == 3
+    assert struct.items == [1, 2, 3]
   end
 
   @thrift_file name: "complex_typedefs.thrift",


### PR DESCRIPTION
Fixes #408.

There were two elements of the AST that were having their namespaces handled the same, though they are actually supposed to be different. `TypeRef` and `ValueRef`.

`ValueRef`s refer to enums, and the logic is supposed to be that if its fully-qualified name already has the current module in it (ex: `additions.ChocolateAdditions.ALMONDS`), then we don't re-add the module (as this would result in `additions.additions.ChocolateAdditions.ALMONDS`).

This logic was also being applied to `TypeRef`s, however there's an edge case that it doesn't work on. If a typeref already refers to a qualified type (ex: `typedef shared.Integer MyInteger`), an extra module could get prepended (ex: `current_module.shared.Integer`). This is invalid.

The fix is to break up `add_namespace_to_type` into two functions: `add_namespace_to_type` and `add_namespace_to_value`, and handle this edge case.

I think this makes sense. I fear this introduces more edge cases somehow. I tried to test a bunch of cases I could think of, but hopefully I'm not missing any?