### PR TITLE
Stop generating a `@moduledoc` for enum modules

### DIFF
--- a/lib/thrift/generator/enum_generator.ex
+++ b/lib/thrift/generator/enum_generator.ex
@@ -60,7 +60,7 @@ defmodule Thrift.Generator.EnumGenerator do
 
     quote do
       defmodule unquote(name) do
-        @moduledoc unquote("Auto-generated Thrift enum #{enum.name}")
+        @moduledoc false
         unquote_splicing(macro_defs)
 
         unquote_splicing(value_to_name_defs)


### PR DESCRIPTION
We no longer generate documentation for any of the other types.