### PR TITLE
Add CODEOWNERS listing global project reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dantswain @fishcakez @jparise @pguillory @scohen @thecodeboss


### PR DESCRIPTION
See: https://help.github.com/articles/about-codeowners/