### PR TITLE
Remove an unnecessary cast/2 function head

### DIFF
--- a/lib/thrift/parser/conversions.ex
+++ b/lib/thrift/parser/conversions.ex
@@ -37,10 +37,6 @@ defmodule Thrift.Parser.Conversions do
     ref
   end
 
-  def cast(:double, val) do
-    val
-  end
-
   def cast(:bool, 0), do: false
   def cast(:bool, 1), do: true
 


### PR DESCRIPTION
The default `def cast(_, val), do: val` function already handles :double
just fine.