### PR TITLE
Guard path using is_binary/1, not is_bitstring/1

### DIFF
--- a/lib/thrift/ast.ex
+++ b/lib/thrift/ast.ex
@@ -457,7 +457,7 @@ defmodule Thrift.AST do
 
     defp module_name(nil), do: nil
 
-    defp module_name(path) when is_bitstring(path) do
+    defp module_name(path) when is_binary(path) do
       path
       |> Path.basename()
       |> Path.rootname()


### PR DESCRIPTION
Paths will always be made up of full bytes.