### PR TITLE
Require at least Elixir 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ branches:
 
 matrix:
   include:
-    - elixir: 1.5
-      otp_release: 19.3
     - elixir: 1.6
       otp_release: 19.3
     - elixir: 1.7

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Thrift.Mixfile do
     [
       app: :thrift,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.6",
       deps: deps(),
 
       # Build Environment


### PR DESCRIPTION
This has the following advantages (at the expense of broader
compatibility):

1. It allows us to use Mix.Compiler.Task for our compiler task (#363).
2. We can rely on the formatter always being available.
3. Just before releasing 2.0 is a good time to require a recent version.