### PR TITLE
Revise the code ownership assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-* @dantswain @fishcakez @jparise @pguillory @scohen @thecodeboss
+# Global
+* @fishcakez @jparise @scohen @thecodeboss
+
+# Code generation
+lib/thrift/generator/ @dantswain @pguillory
+lib/thrift/generator.ex @dantswain @pguillory


### PR DESCRIPTION
Reduce the set of global reviewers and break out the code generation
code into its own list.