### PR TITLE
Add exception return type to client typespec

### DIFF
--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -23,7 +23,7 @@ defmodule Thrift.Binary.Framed.Client do
 
   @immutable_tcp_opts [active: false, packet: 4, mode: :binary]
 
-  @type error :: {:error, atom}
+  @type error :: {:error, atom} | {:error, {:exception, struct}}
   @type success :: {:ok, binary}
 
   @type protocol_response :: success | error


### PR DESCRIPTION
When doing `Client.call(...)`, it's possible it will return a `{:error, {:exception, struct}}` tuple (and many of our tests confirm this).

However the type definition does not reflect this, and so Dialyzer complains on generated code saying the `{:error, {:exception, ex}}` clause will never match `{:error, atom}`.