### PR TITLE
(WIP) Introduce Thrift.Serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,15 @@ end
 
 ## Serialization
 
-A `BinaryProtocol` module is generated for each Thrift struct, union, and
-exception type. You can use this interface to easily serialize and deserialize
-your own types.
+Each thrift struct, union and exception also has a `SerDe` protocol generated for
+it. This module lets you serialize and deserialize its own type easily via `Thrift.Serializable`.
 
 ```elixir
 iex> alias Calculator.Generated.Vector
 iex> data = %Vector{x: 1, y: 2, z: 3}
-|> Vector.BinaryProtocol.serialize
-|> IO.iodata_to_binary
-iex> Vector.BinaryProtocol.deserialize(data)
-{%Calculator.Generated.Vector{x: 1.0, y: 2.0, z: 3.0}, ""}
+|> Thrift.Serializable.serialize(%Thrift.Binary{payload: ""})
+iex> Thrift.Serializable.deserialize(%Vector{}, data)
+{%Calculator.Generated.Vector{x: 1.0, y: 2.0, z: 3.0}, %Thrift.Protocol.Binary{payload: ""}}
 ```
 
 ## Thrift IDL Parsing

--- a/lib/thrift.ex
+++ b/lib/thrift.ex
@@ -78,15 +78,15 @@ defmodule Thrift do
   ... the generated code will be placed in the following modules under
   `lib/thrift/`:
 
-    Definition                | Module
-    ------------------------- | -----------------------------------------------
-    `User` struct             | `Thrift.Test.User`
-    *└ binary protocol*       | `Thrift.Test.User.BinaryProtocol`
-    `UserNotFound` exception  | `Thrift.Test.UserNotFound`
-    *└ binary protocol*       | `Thrift.Test.UserNotFound.BinaryProtocol`
-    `UserService` service     | `Thrift.Test.UserService.Handler`
-    *└ binary framed client*  | `Thrift.Test.UserService.Binary.Framed.Client`
-    *└ binary framed server*  | `Thrift.Test.UserService.Binary.Framed.Server`
+    Definition                 | Module
+    -------------------------- | -----------------------------------------------
+    `User` struct              | `Thrift.Test.User`
+    *└ serialization protocol* | `Thrift.Test.User.SerDe`
+    `UserNotFound` exception   | `Thrift.Test.UserNotFound`
+    *└ serialization protocol* | `Thrift.Test.UserNotFound.SerDe`
+    `UserService` service      | `Thrift.Test.UserService.Handler`
+    *└ binary framed client*   | `Thrift.Test.UserService.Binary.Framed.Client`
+    *└ binary framed server*   | `Thrift.Test.UserService.Binary.Framed.Server`
 
   ### Namespaces
 

--- a/lib/thrift/generator/service.ex
+++ b/lib/thrift/generator/service.ex
@@ -23,8 +23,8 @@ defmodule Thrift.Generator.Service do
         generate_response_struct(schema, function)
       end
 
-    framed_client = Generator.Binary.Framed.Client.generate(service)
-    framed_server = Generator.Binary.Framed.Server.generate(dest_module, service, file_group)
+    framed_client = Generator.Client.generate(service)
+    framed_server = Generator.Server.generate(dest_module, service, file_group)
 
     service_module =
       quote do

--- a/lib/thrift/protocol.ex
+++ b/lib/thrift/protocol.ex
@@ -1,0 +1,8 @@
+defmodule Thrift.Protocol do
+  @moduledoc false
+
+  @doc """
+  Generate quoted expression for implementing SerDe protocol for a struct.
+  """
+  @callback serde_impl(module, Thrift.AST.Struct.t, Thrift.FileGroup.t) :: Macro.expr
+end

--- a/lib/thrift/serializable.ex
+++ b/lib/thrift/serializable.ex
@@ -1,0 +1,18 @@
+defprotocol Thrift.Serializable do
+  @moduledoc """
+  Protocol to serialize and deserialize thrift structs.
+  """
+
+  @doc """
+  Serialize a struct to a payload
+  """
+  @spec serialize(thrift_struct, payload) :: payload when thrift_struct: struct, payload: var
+  def serialize(thrift_struct, payload)
+
+  @doc """
+  Deserialize a struct from a payload.
+  """
+  @spec deserialize(thrift_struct, payload) ::
+    {thrift_struct, payload} | :error when thrift_struct: struct, payload: var
+  def deserialize(thrift_struct, payload)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Thrift.Mixfile do
 
       # Build Environment
       elixirc_paths: elixirc_paths(Mix.env()),
+      consolidate_protocols: Mix.env() != :test,
       compilers: [:leex, :yecc, :erlang, :elixir, :app],
 
       # Testing

--- a/test/support/lib/parser_utils.ex
+++ b/test/support/lib/parser_utils.ex
@@ -26,6 +26,7 @@ end
 defmodule ParserUtils do
   @moduledoc false
   alias Thrift.Parser
+  alias Thrift.Protocol.Binary
 
   def parse_thrift(file_path) do
     Parser.parse_file(file_path)
@@ -101,7 +102,7 @@ defmodule ParserUtils do
   end
 
   def serialize_user_elixir(user, opts \\ []) do
-    serialized = User.BinaryProtocol.serialize(user)
+    %Binary{payload: serialized} = Thrift.Serializable.serialize(user, %Binary{payload: ""})
 
     if Keyword.get(opts, :convert_to_binary, true) do
       IO.iodata_to_binary(serialized)
@@ -111,7 +112,7 @@ defmodule ParserUtils do
   end
 
   def deserialize_user_elixir(binary_data) do
-    {%User{}, ""} = User.BinaryProtocol.deserialize(binary_data)
+    {%User{}, %Binary{payload: ""}} = Thrift.Serializable.deserialize(%Binary{payload: binary_data}, %User{})
   end
 
   def deserialize_user_erlang(binary_data) do
@@ -142,8 +143,7 @@ defmodule ParserUtils do
   def serialize_nesting(nesting, opts \\ [])
 
   def serialize_nesting(nesting, opts) when is_map(nesting) do
-    alias Nesting.BinaryProtocol
-    serialized = BinaryProtocol.serialize(:struct, nesting)
+    %Binary{payload: serialized} = Thrift.Serializable.serialize(nesting, %Binary{payload: %{}})
 
     if Keyword.get(opts, :convert_to_binary, true) do
       IO.iodata_to_binary(serialized)

--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -77,9 +77,16 @@ defmodule ThriftTestCase do
         []
 
       modules ->
-        parts = Enum.map(modules, fn {module, _} -> Module.split(module) end)
+        parts = modules
+          |> Enum.reject(fn {module, _} -> protocol?(module) end)
+          |> Enum.map(fn {module, _} -> Module.split(module) end)
         for part <- parts, alias?(part, parts), do: Module.concat(part)
     end
+  end
+
+  defp protocol?(module) do
+    attrs = module.__info__(:attributes)
+    Keyword.has_key?(attrs, :protocol) or Keyword.has_key?(attrs, :protocol_impl)
   end
 
   defp alias?(module, modules) do

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -1,6 +1,9 @@
 defmodule Thrift.Generator.ServiceTest do
   use ThriftTestCase
 
+  alias Thrift.Serializable
+  alias Thrift.Protocol.Binary
+
   @thrift_file name: "simple_service.thrift",
                contents: """
                namespace elixir Services.Simple
@@ -168,7 +171,8 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameArgs{id: 1234, new_username: "stinkypants"}
-      |> UpdateUsernameArgs.BinaryProtocol.serialize()
+      |> Serializable.serialize(%Binary{payload: ""})
+      |> Map.fetch!(:payload)
       |> IO.iodata_to_binary()
 
     assert <<10, 0, 1, 0, 0, 0, 0, 0, 0, 4, 210, 11, 0, 2, 0, 0, 0, 11, "stinkypants", 0>> ==
@@ -180,7 +184,8 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameResponse{success: true}
-      |> UpdateUsernameResponse.BinaryProtocol.serialize()
+      |> Serializable.serialize(%Binary{payload: ""})
+      |> Map.fetch!(:payload)
       |> IO.iodata_to_binary()
 
     assert <<2, 0, 0, 1, 0>> == serialized
@@ -194,7 +199,8 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameResponse{taken: %UsernameTakenException{message: "That username is taken"}}
-      |> UpdateUsernameResponse.BinaryProtocol.serialize()
+      |> Serializable.serialize(%Binary{payload: ""})
+      |> Map.fetch!(:payload)
       |> IO.iodata_to_binary()
 
     assert <<12, 0, 1, 11, 0, 1, 0, 0, 0, 22, rest::binary>> = serialized

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -2,26 +2,15 @@ defmodule BinaryProtocolTest do
   use ThriftTestCase, async: true
 
   alias Thrift.Protocol.Binary
-
-  defp serialize(module, struct) do
-    struct
-    |> module.serialize
-    |> IO.iodata_to_binary()
-  end
-
-  defp deserialize(module, binary_data) do
-    {struct, ""} = module.deserialize(binary_data)
-    struct
-  end
+  alias Thrift.Serializable
 
   defp assert_serde(%module{} = struct, thrift_binary_file) do
     thrift_binary_file = Path.join("test/data/binary", thrift_binary_file)
-    binary_protocol_module = Module.safe_concat(module, BinaryProtocol)
     thrift_binary = File.read!(thrift_binary_file)
 
-    serialized = serialize(binary_protocol_module, struct)
-    deserialized_test_data = deserialize(binary_protocol_module, thrift_binary)
-    assert deserialize(binary_protocol_module, serialized) == deserialized_test_data
+    serialized = Serializable.serialize(struct, %Binary{payload: ""})
+    deserialized_test_data = Serializable.deserialize(module.new(), %Binary{payload: thrift_binary})
+    assert Serializable.deserialize(module.new(), serialized) == deserialized_test_data
   end
 
   @thrift_file name: "enums.thrift",
@@ -75,7 +64,7 @@ defmodule BinaryProtocolTest do
   end
 
   thrift_test "it should not encode unset fields" do
-    assert <<0>> == IO.iodata_to_binary(Scalars.serialize(%Scalars{}))
+    assert <<0>> == IO.iodata_to_binary(Serializable.serialize(%Scalars{}, %Binary{payload: ""}).payload)
   end
 
   @thrift_file name: "containers.thrift",
@@ -236,8 +225,8 @@ defmodule BinaryProtocolTest do
       new_enum: Grooviness.partially_good()
     }
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -251,8 +240,8 @@ defmodule BinaryProtocolTest do
       new_substruct: sub_struct
     }
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -262,8 +251,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234", sub_sub: sub_sub}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_substruct: sub}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -272,8 +261,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_list: [sub]}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -282,8 +271,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_set: MapSet.new([sub, sub])}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -292,8 +281,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_map: %{1 => sub, 2 => sub}}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -318,8 +307,8 @@ defmodule BinaryProtocolTest do
 
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", my_twin: twin}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = Serializable.serialize(changey, %Binary{payload: ""})
+    {deserialized, %Binary{payload: ""}} = Serializable.deserialize(%OldChangeyStruct{}, serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end


### PR DESCRIPTION
WIP for #343 and improve support for other protocols (#333). Note I did not implement the proposed `Thrift.Message` as it was not required for an initial step. The main goal is to do minimal work to get `Thrift.Serializable` working and a step towards making the code generation for a client or server protocol independent.

Having to use %Thrift.Protocol.Binary{} to wrap binaries everywhere is awkward, perhaps we should implement `binary` for `Thrift.Serializable` or `Struct.SerDe` that does binary protocol too? On the other hand this should be abstracted for most usecases. I think if we wish to have Binary and Compact on equal footing we should not allow that as we want to ensure to type the payloads...