### PR TITLE
Remove "include name" concept from FileRef

### DIFF
--- a/lib/thrift/parser/file_group.ex
+++ b/lib/thrift/parser/file_group.ex
@@ -25,8 +25,8 @@ defmodule Thrift.Parser.FileGroup do
 
   @type t :: %FileGroup{
           initial_file: Path.t(),
-          parsed_files: %{FileRef.thrift_include() => %ParsedFile{}},
-          schemas: %{FileRef.thrift_include() => %Schema{}},
+          parsed_files: %{Path.t() => %ParsedFile{}},
+          schemas: %{Path.t() => %Schema{}},
           namespaces: %{atom => String.t() | nil},
           opts: Parser.opts()
         }

--- a/lib/thrift/parser/file_ref.ex
+++ b/lib/thrift/parser/file_ref.ex
@@ -1,19 +1,14 @@
 defmodule Thrift.Parser.FileRef do
   @moduledoc false
 
-  @type thrift_include :: String.t()
-  @type t :: %__MODULE__{path: String.t(), include_name: String.t(), contents: String.t()}
-  defstruct path: nil, include_name: nil, contents: nil
+  @type t :: %__MODULE__{path: Path.t(), contents: String.t()}
+  defstruct path: nil, contents: nil
 
   def new(path) do
     # We include the __file__ here to hack around the fact that leex and yecc don't
     # operate on files and lose the file info. This is relevant because the filename is
     # turned into the thrift module, and is necessary for resolution.
     thrift_file = File.read!(path) <> "\n__file__ \"#{path}\""
-    %__MODULE__{path: path, include_name: include_name(path), contents: thrift_file}
-  end
-
-  def include_name(path) do
-    Path.basename(path, ".thrift")
+    %__MODULE__{path: path, contents: thrift_file}
   end
 end

--- a/lib/thrift/parser/parsed_file.ex
+++ b/lib/thrift/parser/parsed_file.ex
@@ -11,7 +11,11 @@ defmodule Thrift.Parser.ParsedFile do
   def new(%FileRef{} = file_ref) do
     case Parser.parse(file_ref.contents) do
       {:ok, schema} ->
-        %__MODULE__{file_ref: file_ref, schema: schema, name: FileRef.include_name(file_ref.path)}
+        %__MODULE__{
+          file_ref: file_ref,
+          schema: schema,
+          name: Path.basename(file_ref.path, ".thrift")
+        }
 
       {:error, error} ->
         raise Thrift.FileParseError, {file_ref, error}


### PR DESCRIPTION
First, remove `FileRef.include_name/1` and the struct field of the same
name. These were really never being used. Instead, we can construct the
`ParsedFile.name` field value directly.

Also, remove the `FileRef.thrift_include` type and just use `Path.t()` in its
place. This is also more correct than the former's `String.t()` spec.