### PR TITLE
Add filename to parse error tuple

### DIFF
--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -88,8 +88,8 @@ defmodule Thrift.FileParseError do
   end
 
   # display the line number if we get it
-  defp format_error({line_no, message}) do
-    " on line #{line_no}: #{message}"
+  defp format_error({_path, line, message}) do
+    " on line #{line}: #{message}"
   end
 
   defp format_error(error) do

--- a/test/thrift/parser/parse_error_test.exs
+++ b/test/thrift/parser/parse_error_test.exs
@@ -55,7 +55,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     /8
     """
 
-    assert {:error, {2, _}} = parse_string(contents)
+    assert {:error, {nil, 2, _}} = parse_string(contents)
 
     path = Path.join(@test_file_dir, "lexer_error.thrift")
     File.write!(path, contents)

--- a/test/thrift/parser/parser_test.exs
+++ b/test/thrift/parser/parser_test.exs
@@ -897,7 +897,7 @@ defmodule Thrift.Parser.ParserTest do
   end
 
   test "names cannot override built-in keywords" do
-    assert {:error, {1, ~S(cannot use reserved language keyword "continue")}} ==
+    assert {:error, {nil, 1, ~S(cannot use reserved language keyword "continue")}} ==
              parse_string("struct continue {}")
   end
 


### PR DESCRIPTION
This will give us a way to report more detailed errors from included
files. We currently only report those kinds of nested errors using
FileParseError exceptions.