### PR TITLE
parse_file_group/2 now returns a list of errors

### DIFF
--- a/lib/thrift/exceptions.ex
+++ b/lib/thrift/exceptions.ex
@@ -81,19 +81,9 @@ defmodule Thrift.FileParseError do
 
   # Exception callback, should not be called by end user
   @doc false
-  @spec exception({Path.t(), term}) :: Exception.t()
-  def exception({path, error}) do
-    msg = "Error parsing thrift file #{path}#{format_error(error)}"
-    %__MODULE__{message: msg}
-  end
-
-  # display the line number if we get it
-  defp format_error({_path, line, message}) do
-    " on line #{line}: #{message}"
-  end
-
-  defp format_error(error) do
-    ": #{inspect(error)}"
+  @spec exception(Thrift.Parser.error()) :: Exception.t()
+  def exception({path, line, message}) do
+    %__MODULE__{message: "Parse error at #{path}:#{line}: #{message}"}
   end
 end
 

--- a/test/mix/tasks/thrift.generate_test.exs
+++ b/test/mix/tasks/thrift.generate_test.exs
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Thrift.GenerateTest do
       bad_file = Path.join([@temp_dir, "invalid.thrift"])
       File.write!(bad_file, bad_schema)
 
-      assert_raise Mix.Error, ~r/Error parsing/, fn ->
+      assert_raise Mix.Error, ~r/Parse error/, fn ->
         run([bad_file])
       end
     end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,7 +33,8 @@ defmodule ThriftTestHelpers do
   end
 
   def parse(file_path) do
-    Thrift.Parser.parse_file_group!(file_path)
+    {:ok, group} = Thrift.Parser.parse_file_group(file_path)
+    group
   end
 
   @spec with_thrift_files(Keyword.t(), String.t()) :: nil

--- a/test/thrift/parser/parse_error_test.exs
+++ b/test/thrift/parser/parse_error_test.exs
@@ -4,7 +4,7 @@ defmodule Thrift.Parser.ParseErrorTest do
   @project_root Path.expand("../..", __DIR__)
   @test_file_dir Path.join([@project_root, "tmp", "parse_error_test"])
 
-  import Thrift.Parser, only: [parse_string: 1, parse_file_group!: 1]
+  import Thrift.Parser, only: [parse_string: 1, parse_file_group: 1]
 
   setup do
     File.rm_rf!(@test_file_dir)
@@ -19,16 +19,12 @@ defmodule Thrift.Parser.ParseErrorTest do
     }
     """
 
-    assert {:error, _} = parse_string(contents)
+    assert {:error, {nil, 1, _}} = parse_string(contents)
 
     path = Path.join(@test_file_dir, "syntax_error.thrift")
     File.write!(path, contents)
 
-    assert_raise(
-      Thrift.FileParseError,
-      ~r/#{path} on line 1:/,
-      fn -> parse_file_group!(path) end
-    )
+    assert {:error, [{^path, 1, "syntax error before: \"stract\""}]} = parse_file_group(path)
 
     other_path = Path.join(@test_file_dir, "includes_syntax_error.thrift")
 
@@ -42,11 +38,8 @@ defmodule Thrift.Parser.ParseErrorTest do
 
     # should raise an error on the included file,
     # since that is where the syntax error is
-    assert_raise(
-      Thrift.FileParseError,
-      ~r/#{path} on line 1:/,
-      fn -> parse_file_group!(other_path) end
-    )
+    assert {:error, [{^path, 1, "syntax error before: \"stract\""}]} =
+             parse_file_group(other_path)
   end
 
   test "a file that throws lexer errors raises an exception" do
@@ -60,11 +53,7 @@ defmodule Thrift.Parser.ParseErrorTest do
     path = Path.join(@test_file_dir, "lexer_error.thrift")
     File.write!(path, contents)
 
-    assert_raise(
-      Thrift.FileParseError,
-      ~r/#{path} on line 2:/,
-      fn -> parse_file_group!(path) end
-    )
+    assert {:error, [{^path, 2, "illegal characters \"/8\""}]} = parse_file_group(path)
 
     other_path = Path.join(@test_file_dir, "includes_syntax_error.thrift")
 
@@ -78,10 +67,6 @@ defmodule Thrift.Parser.ParseErrorTest do
 
     # should raise an error on the included file,
     # since that is where the syntax error is
-    assert_raise(
-      Thrift.FileParseError,
-      ~r/#{path} on line 2:/,
-      fn -> parse_file_group!(other_path) end
-    )
+    assert {:error, [{^path, 2, "illegal characters \"/8\""}]} = parse_file_group(other_path)
   end
 end

--- a/test/thrift/parser_test.exs
+++ b/test/thrift/parser_test.exs
@@ -5,7 +5,7 @@ defmodule Thrift.Parser.ParserTest do
   @test_file_dir Path.join([@project_root, "tmp", "parser_test"])
 
   import Thrift.Parser,
-    only: [parse_string: 1, parse_file: 1, parse_file_group!: 2]
+    only: [parse_string: 1, parse_file: 1, parse_file_group: 2]
 
   alias Thrift.AST.{
     Constant,
@@ -925,7 +925,7 @@ defmodule Thrift.Parser.ParserTest do
     end
 
     defp parse_namespace(context, namespace) do
-      result = parse_file_group!(context[:path], namespace: namespace)
+      {:ok, result} = parse_file_group(context[:path], namespace: namespace)
       result.namespaces[:module]
     end
 


### PR DESCRIPTION
Because this function parses a tree of files (the root file plus all of
its recursively included files), return a separate error tuple for each
error that occurred.

FileParseError still exists but only captures the first error in the
list. I intend to remove this exception soon, so this is fine for now.

Also, while I'm here, move parser_test.exs so that it mirrors the
parser.ex location.