### PR TITLE
Remove Thrift.Generator.generate!/2 variant

### DIFF
--- a/lib/thrift/generator.ex
+++ b/lib/thrift/generator.ex
@@ -38,12 +38,6 @@ defmodule Thrift.Generator do
     |> Kernel.<>(".ex")
   end
 
-  def generate!(thrift_filename, output_dir) when is_bitstring(thrift_filename) do
-    thrift_filename
-    |> Thrift.Parser.parse_file_group!()
-    |> generate!(output_dir)
-  end
-
   def generate!(%FileGroup{} = file_group, output_dir) do
     Enum.flat_map(file_group.schemas, fn {_, schema} ->
       schema

--- a/test/support/lib/thrift_test_case.ex
+++ b/test/support/lib/thrift_test_case.ex
@@ -90,6 +90,7 @@ defmodule ThriftTestCase do
   defp generate_files(files, namespace, dir) do
     files
     |> Enum.map(&write_thrift_file(&1, namespace, dir))
+    |> Enum.map(&Thrift.Parser.parse_file_group!(&1))
     |> Enum.flat_map(&Thrift.Generator.generate!(&1, dir))
     |> Enum.flat_map(&require_file(&1, dir))
     |> Enum.each(&Module.put_attribute(namespace, :thrift_elixir_modules, &1))


### PR DESCRIPTION
This function variant was only used by the test code as a convenience
for parsing and generating in one call. Instead, we can perform the
parsing step as part of the full generation pipeline.

Removing the function eliminates the last call dependency between the
generator and the parser.