### PR TITLE
Revise generated server function catch clauses

### DIFF
--- a/example/lib/calculator/generated/service.ex
+++ b/example/lib/calculator/generated/service.ex
@@ -844,8 +844,6 @@ defmodule(Calculator.Generated.Service) do
               {:reply,
                Elixir.Calculator.Generated.Service.AddResponse.BinaryProtocol.serialize(response)}
             )
-          rescue
-            []
           catch
             kind, reason ->
               formatted_exception = Exception.format(kind, reason, System.stacktrace())
@@ -887,15 +885,15 @@ defmodule(Calculator.Generated.Service) do
                  response
                )}
             )
-          rescue
-            e in Calculator.Generated.DivideByZeroError ->
+          catch
+            :error, %Calculator.Generated.DivideByZeroError{} = e ->
               response = %Calculator.Generated.Service.DivideResponse{e: e}
 
               {:reply,
                Elixir.Calculator.Generated.Service.DivideResponse.BinaryProtocol.serialize(
                  response
                )}
-          catch
+
             kind, reason ->
               formatted_exception = Exception.format(kind, reason, System.stacktrace())
 
@@ -936,8 +934,6 @@ defmodule(Calculator.Generated.Service) do
                  response
                )}
             )
-          rescue
-            []
           catch
             kind, reason ->
               formatted_exception = Exception.format(kind, reason, System.stacktrace())
@@ -979,8 +975,6 @@ defmodule(Calculator.Generated.Service) do
                  response
                )}
             )
-          rescue
-            []
           catch
             kind, reason ->
               formatted_exception = Exception.format(kind, reason, System.stacktrace())
@@ -1025,8 +1019,6 @@ defmodule(Calculator.Generated.Service) do
                  response
                )}
             )
-          rescue
-            []
           catch
             kind, reason ->
               formatted_exception = Exception.format(kind, reason, System.stacktrace())


### PR DESCRIPTION
wrap_with_try_catch/4 wraps a function handler body with try/1.

Our previous approach used `rescue` clauses for exception types defined
for this function in the schema. When no exception types are defined,
this resulted in us passing [] (empty list) into the macro as the
`rescue` argument. Elixir 1.10 doesn't like that:

    expected -> clauses for :rescue in "try"

This revised approach moves exception type handling into the existing
`catch` list (and does away with `rescue`), merging them with our
existing `catch` clause that is common to all server functions. This
guarantees that we always have at least one clause to expand in the
macro.

Fixes #495