### PR TITLE
Refactor Thrift.Transport.SSL.configuration/1

### DIFF
--- a/lib/thrift/transport/ssl.ex
+++ b/lib/thrift/transport/ssl.ex
@@ -33,7 +33,7 @@ defmodule Thrift.Transport.SSL do
           {:ok, opts} ->
             handle_optional(opts)
 
-          {:error, %_exception{}} = error ->
+          {:error, _} = error ->
             error
         end
 


### PR DESCRIPTION
The implementation did not respect its type signature, which specified that the
error form of the return value should contain an exception as the second
element. This expectation is relied upon by maybe_ssl_handshake. However the
callback passed in the :configure option could return anything, and we return
its response without fully verifying that it matches the configuration
typespec.

Also refactored the code for clarity.