### PR TITLE
Add server side metrics

### DIFF
--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -294,7 +294,7 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
     transport.close(socket)
   end
 
-  defp start_span(metric_name, %__MODULE__{handler_module: handler_module}, tags \\ %{}) do
+  defp start_span(metric_name, %__MODULE__{handler_module: handler_module}, tags \\ []) do
     event_name = [Thrift, handler_module, metric_name]
     time = System.monotonic_time()
     metadata = tags_to_metadata(tags)

--- a/lib/thrift/binary/framed/protocol_handler.ex
+++ b/lib/thrift/binary/framed/protocol_handler.ex
@@ -224,7 +224,8 @@ defmodule Thrift.Binary.Framed.ProtocolHandler do
       {:server_error, %TApplicationException{} = exc} ->
         finish_span(span, result: "error")
 
-        serialized_message = Binary.serialize(:message_begin, {:exception, sequence_id, method_name})
+        serialized_message =
+          Binary.serialize(:message_begin, {:exception, sequence_id, method_name})
 
         serialized_exception = Binary.serialize(:application_exception, exc)
 

--- a/mix.exs
+++ b/mix.exs
@@ -85,7 +85,8 @@ defmodule Thrift.Mixfile do
 
       # Runtime
       {:connection, "~> 1.0"},
-      {:ranch, "~> 1.6"}
+      {:ranch, "~> 1.6"},
+      {:telemetry, "~> 0.3"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.5.0", "8516502659002cec19e244ebd90d312183064be95025a319a6c7e89f4bccd65b", [:rebar3], [], "hexpm", "d48d002e15f5cc105a696cf2f1bbb3fc72b4b770a184d8420c8db20da2674b38"},
 }

--- a/test/support/lib/stub_stats.ex
+++ b/test/support/lib/stub_stats.ex
@@ -1,0 +1,67 @@
+defmodule StubStats do
+  use GenServer
+
+  defmacro __using__(_) do
+    quote do
+      import unquote(__MODULE__), only: [stats: 1, reset_stats: 0]
+    end
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def stats(metric_name) do
+    GenServer.call(__MODULE__, {:stats, metric_name})
+  end
+
+  def reset_stats do
+    GenServer.call(__MODULE__, :reset_stats)
+  end
+
+  def init(opts) do
+    handler_module = Keyword.fetch!(opts, :handler_module)
+
+    events = [
+      [Thrift, handler_module, :peek_first_byte],
+      [Thrift, handler_module, :ssl_handshake],
+      [Thrift, handler_module, :receive_message],
+      [Thrift, handler_module, :call],
+      [Thrift, handler_module, :send_reply],
+      [Thrift, handler_module, :request_size],
+      [Thrift, handler_module, :response_size]
+    ]
+
+    callback = &GenServer.call(__MODULE__, {:metric, &1, &2, &3, &4})
+
+    :ok = :telemetry.attach_many(inspect(self()), events, callback, nil)
+    {:ok, []}
+  end
+
+  def terminate(reason, _state) do
+    IO.inspect(reason, label: "StubStats terminate reason")
+    :telemetry.detach(inspect(self()))
+  end
+
+  def handle_call({:metric, event, _measurements, metadata, nil}, _, state) do
+    [Thrift, _handler_module, metric_name] = event
+    state = [{metric_name, metadata} | state]
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:stats, metric_name}, _, state) do
+    metadatas =
+      state
+      |> Enum.flat_map(fn
+        {^metric_name, metadata} -> [metadata]
+        {_, _} -> []
+      end)
+      |> Enum.reverse()
+
+    {:reply, metadatas, state}
+  end
+
+  def handle_call(:reset_stats, _, _) do
+    {:reply, :ok, []}
+  end
+end


### PR DESCRIPTION
We could use server-side metrics for Thrift services. Standard metrics for
every endpoint like QPS, latency, request/response size, and success rate.

In order to avoid coupling to our internal metrics library, I left the
interface pluggable. This also facilitates testing by substituting a stub
implementation in tests.