### PR TITLE
Validate SSL configuration before starting server

### DIFF
--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -1,6 +1,4 @@
 defmodule Thrift.Binary.Framed.Server do
-  require Logger
-
   @moduledoc """
   A server implementation of Thrift's Binary Framed protocol.
 

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -87,7 +87,7 @@ defmodule Thrift.Binary.Framed.Server do
   def validate_ssl_configuration!(ssl_opts) do
     case Thrift.Transport.SSL.configuration(ssl_opts) do
       {:error, %_exception{} = err} ->
-        Logger.error("Error validating SSL configuration: " <> Exception.format(:error, err, []))
+        raise err
 
       nil ->
         :ok

--- a/test/thrift/binary/framed/ssl_test.exs
+++ b/test/thrift/binary/framed/ssl_test.exs
@@ -121,6 +121,25 @@ defmodule Servers.Binary.Framed.SSLTest do
     end
   end
 
+  # @tag ssl_opts: [configure: {__MODULE__, :bad_configure, []}]
+  thrift_test "it refuses to start with bad SSL configuration", ctx do
+    configure = fn ->
+      try do
+        raise "uh oh"
+      rescue
+        exception -> {:error, exception}
+      end
+    end
+
+    assert_raise(RuntimeError, "uh oh", fn ->
+      Server.start_link(
+        ctx[:handler_name],
+        0,
+        ssl_opts: [enabled: true, configure: configure, optional: true]
+      )
+    end)
+  end
+
   ## Helpers
 
   defp get_certs() do


### PR DESCRIPTION
If SSL certs are not available, then every SSL connection will fail. We should
check for this condition at startup before opening the port. That way if a new
node joins a cluster and its SSL configuration is not ready, it won't try to
start accepting connections that could have gone to a healthy host.