### PR TITLE
Pin actions/setup-elixir to any v1 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       MIX_ENV: test
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-elixir@v1.2.0
+      - uses: actions/setup-elixir@v1
         with:
           otp-version: 22.2
           elixir-version: '1.10'
@@ -36,8 +36,8 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: actions/setup-elixir@v1.2.0
+      - uses: actions/checkout@v1
+      - uses: actions/setup-elixir@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}


### PR DESCRIPTION
We expect compatibility along this entire semantic version tag, and this
ensure we'll continue to pick up minor version updates.