### PR TITLE
Drop support for Elixir 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         otp: [22.2]
-        elixir: [1.6, 1.7, 1.8, 1.9, '1.10']
+        elixir: [1.7, 1.8, 1.9, '1.10']
     env:
       MIX_ENV: test
     steps:

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Thrift.Mixfile do
     [
       app: :thrift,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       deps: deps(),
 
       # Build Environment


### PR DESCRIPTION
Some of our dependencies are starting to require Elixir 1.7+ so follow
suite.