### PR TITLE
Add connect_func option to server

### DIFF
--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -49,7 +49,7 @@ defmodule Thrift.Binary.Framed.Server do
     worker_count = Keyword.get(opts, :worker_count, 1)
     tcp_opts = Keyword.get(opts, :tcp_opts, [])
     ssl_opts = Keyword.get(opts, :ssl_opts, [])
-    connect_func = Keyword.get(opts, :connect_func)
+    on_connect = Keyword.get(opts, :on_connect)
 
     transport_opts =
       opts
@@ -65,7 +65,7 @@ defmodule Thrift.Binary.Framed.Server do
         :ranch_tcp,
         transport_opts,
         Thrift.Binary.Framed.ProtocolHandler,
-        {server_module, handler_module, connect_func, tcp_opts, ssl_opts}
+        {server_module, handler_module, on_connect, tcp_opts, ssl_opts}
       )
 
     Supervisor.start_link(

--- a/lib/thrift/binary/framed/server.ex
+++ b/lib/thrift/binary/framed/server.ex
@@ -49,6 +49,7 @@ defmodule Thrift.Binary.Framed.Server do
     worker_count = Keyword.get(opts, :worker_count, 1)
     tcp_opts = Keyword.get(opts, :tcp_opts, [])
     ssl_opts = Keyword.get(opts, :ssl_opts, [])
+    connect_func = Keyword.get(opts, :connect_func)
 
     transport_opts =
       opts
@@ -64,7 +65,7 @@ defmodule Thrift.Binary.Framed.Server do
         :ranch_tcp,
         transport_opts,
         Thrift.Binary.Framed.ProtocolHandler,
-        {server_module, handler_module, tcp_opts, ssl_opts}
+        {server_module, handler_module, connect_func, tcp_opts, ssl_opts}
       )
 
     Supervisor.start_link(

--- a/test/thrift/binary/framed/server_test.exs
+++ b/test/thrift/binary/framed/server_test.exs
@@ -89,12 +89,12 @@ defmodule Servers.Binary.Framed.IntegrationTest do
   setup_all do
     {:ok, connect_agent} = Agent.start_link(fn -> [] end)
 
-    connect_func = fn socket ->
+    on_connect = fn socket ->
       Agent.update(connect_agent, &[socket | &1])
     end
 
     {:module, mod_name, _, _} = define_handler()
-    {:ok, _} = Server.start_link(mod_name, 0, connect_func: connect_func)
+    {:ok, _} = Server.start_link(mod_name, 0, on_connect: on_connect)
     server_port = :ranch.get_port(mod_name)
 
     {:ok, _} = start_supervised({StubStats, handler_module: mod_name})
@@ -204,7 +204,7 @@ defmodule Servers.Binary.Framed.IntegrationTest do
     assert {:ok, true} == Client.ping(name)
   end
 
-  thrift_test "connect_func is called on connect", ctx do
+  thrift_test "on_connect is called on connect", ctx do
     {:ok, true} = Client.ping(ctx.client)
     socket = Agent.get(ctx.connect_agent, fn [socket | _] -> socket end)
     {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(socket)


### PR DESCRIPTION
We'd like to do application-level validation on a client's TLS cert. Currently
it lives within the connection process state, which is not accessible from a
handler function.

In order to make it accessible, this diff allows an optional connect_func
callback to be provided when starting a Thrift server. It will be called after
a TCP or SSL connection is established with the socket as its single parameter.
Given the socket, we can retrieve the client cert using :ssl.peercert/1, and
either do validation immediately or stash the cert in the process dictionary
for validation later in a handler function.