### PR TITLE
Handle unknown method calls

### DIFF
--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -28,6 +28,16 @@ defmodule Thrift.Generator.Binary.Framed.Server do
         end
 
         unquote_splicing(functions)
+
+        def handle_thrift(method, _binary_data, _handler_module) do
+          error =
+            Thrift.TApplicationException.exception(
+              type: :unknown_method,
+              message: "Unknown method: #{method}"
+            )
+
+          {:server_error, error}
+        end
       end
     end
   end


### PR DESCRIPTION
There is a TApplicationException type defined for when a client calls
a method not implemented by the server. This can happen in multiple
situations:

- An IDL change adding a method is deployed to the client before the server.
- A client accidentally connects to the wrong server due to faulty service
  discovery.
- A TTwitter client probes the `__can__finagle__trace__v3__` method.

To explain the last case: A client/server can upgrade from Thrift binary
protocol to another protocol called TTwitter through protocol negotiation. The
client calls the method `__can__finagle__trace__v3__` and expects to receive a
TApplicationException if the server does not support TTwitter, in which they
continue speaking binary protocol. See:
https://twitter.github.io/finagle/guide/Protocols.html

Currently we just crash and close the connection when any unknown method is
called. This diff has it properly return a TApplicationException.