### PR TITLE
replace System.stacktrace/0 with  __STACKTRACE__

### DIFF
--- a/example/lib/calculator/generated/service.ex
+++ b/example/lib/calculator/generated/service.ex
@@ -841,7 +841,7 @@ defmodule(Calculator.Generated.Service) do
             {:reply, Calculator.Generated.Service.AddResponse.BinaryProtocol.serialize(response)}
           catch
             kind, reason ->
-              formatted_exception = Exception.format(kind, reason, System.stacktrace())
+              formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
 
               Logger.error(
                 "Exception not defined in thrift spec was thrown: #{formatted_exception}"
@@ -881,7 +881,7 @@ defmodule(Calculator.Generated.Service) do
                Calculator.Generated.Service.DivideResponse.BinaryProtocol.serialize(response)}
 
             kind, reason ->
-              formatted_exception = Exception.format(kind, reason, System.stacktrace())
+              formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
 
               Logger.error(
                 "Exception not defined in thrift spec was thrown: #{formatted_exception}"
@@ -915,7 +915,7 @@ defmodule(Calculator.Generated.Service) do
              Calculator.Generated.Service.MultiplyResponse.BinaryProtocol.serialize(response)}
           catch
             kind, reason ->
-              formatted_exception = Exception.format(kind, reason, System.stacktrace())
+              formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
 
               Logger.error(
                 "Exception not defined in thrift spec was thrown: #{formatted_exception}"
@@ -949,7 +949,7 @@ defmodule(Calculator.Generated.Service) do
              Calculator.Generated.Service.SubtractResponse.BinaryProtocol.serialize(response)}
           catch
             kind, reason ->
-              formatted_exception = Exception.format(kind, reason, System.stacktrace())
+              formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
 
               Logger.error(
                 "Exception not defined in thrift spec was thrown: #{formatted_exception}"
@@ -986,7 +986,7 @@ defmodule(Calculator.Generated.Service) do
              Calculator.Generated.Service.VectorProductResponse.BinaryProtocol.serialize(response)}
           catch
             kind, reason ->
-              formatted_exception = Exception.format(kind, reason, System.stacktrace())
+              formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
 
               Logger.error(
                 "Exception not defined in thrift spec was thrown: #{formatted_exception}"

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -112,7 +112,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
     catch_clauses =
       quote do
         kind, reason ->
-          formatted_exception = Exception.format(kind, reason, System.stacktrace())
+          formatted_exception = Exception.format(kind, reason, __STACKTRACE__)
           Logger.error("Exception not defined in thrift spec was thrown: #{formatted_exception}")
 
           error =


### PR DESCRIPTION
Fixes this warning `warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead`