### PR TITLE
Stay connected after unknown_method errors

### DIFF
--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -36,7 +36,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
               message: "Unknown method: #{method}"
             )
 
-          {:server_error, error}
+          {:client_error, error}
         end
       end
     end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -446,7 +446,7 @@ defmodule Thrift.Generator.ServiceTest do
     {:ok, nil} = Client.do_some_work(client, "work!")
   end
 
-  thrift_test "it handles unknown method calls", ctx do
+  thrift_test "it stays connected after unknown method calls", ctx do
     {:ok, client} = WrongClient.start_link("127.0.0.1", ctx.port)
 
     # We have a client that implements different methods than the server to
@@ -458,5 +458,8 @@ defmodule Thrift.Generator.ServiceTest do
              type: :unknown_method,
              message: "Unknown method: plang"
            }
+
+    # Still connected.
+    assert {:error, {:exception, exception}} = WrongClient.plang(client)
   end
 end


### PR DESCRIPTION
The unknown_method error was added in dc53fd9d, in part to support TTwitter
protocol negotion (i.e. Finagle). However it still closes the connection after
such an error, which means Finagle clients don't work. They need to be able to
call __can__finagle__trace__v3__, get a TApplicationException, then continue
calling other methods.

The code handling the :server_error tuple is what disconnects after an error.
In general disconnecting is the only safe choice given an internal server
error. However unknown_method belongs to a class of errors where it's safe to
remain connected -- the client has made an invalid request but otherwise the
connection is still in a valid state. So this diff adds a :client_error clause
that is like :server_error except that it keeps the connection open.

Tested with a Java client using Finagle. The client was able to call
__can__finagle__trace__v3__, get the error, then make a normal request.