### PR TITLE
Explicitly set source_ref to "master"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Thrift.Mixfile do
           "CONTRIBUTING.md": [title: "Contributing"],
           "example/README.md": [filename: "example", title: "Example Project"]
         ],
+        source_ref: "master",
         source_url: @project_url,
         groups_for_modules: [
           "Abstract Syntax Tree": ~r"Thrift.AST.*",


### PR DESCRIPTION
ex_doc 0.26.0 changes this value's default to "main".