### PR TITLE
Un-nest generated BinaryProtocol modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
               elixir: 1.11
               otp: 23
               coverage: true
+          - pair:
+              elixir: 1.13
+              otp: 24
     env:
       MIX_ENV: test
     steps:

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ your own types.
 ```elixir
 iex> alias Calculator.Generated.Vector
 iex> data = %Vector{x: 1, y: 2, z: 3}
-|> Vector.BinaryProtocol.serialize
+|> Vector.serialize
 |> IO.iodata_to_binary
-iex> Vector.BinaryProtocol.deserialize(data)
+iex> Vector.deserialize(data)
 {%Calculator.Generated.Vector{x: 1.0, y: 2.0, z: 3.0}, ""}
 ```
 

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -333,9 +333,7 @@ defmodule Thrift.Binary.Framed.Client do
       TApplicationException.exception(
         type: :bad_sequence_id,
         message:
-          "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{
-            mismatched_seq_id
-          }"
+          "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{mismatched_seq_id}"
       )
 
     {:error, {:exception, exception}}

--- a/lib/thrift/binary/framed/client.ex
+++ b/lib/thrift/binary/framed/client.ex
@@ -333,7 +333,9 @@ defmodule Thrift.Binary.Framed.Client do
       TApplicationException.exception(
         type: :bad_sequence_id,
         message:
-          "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{mismatched_seq_id}"
+          "Invalid sequence id. The client sent #{seq_id}, but the server replied with #{
+            mismatched_seq_id
+          }"
       )
 
     {:error, {:exception, exception}}

--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -28,7 +28,6 @@ defmodule Thrift.Generator.Binary.Framed.Client do
 
   defp generate_handler_function(function) do
     args_module = Service.module_name(function, :args)
-    args_binary_module = Module.concat(args_module, :BinaryProtocol)
     response_module = Service.module_name(function, :response)
     rpc_name = Atom.to_string(function.name)
 
@@ -76,7 +75,7 @@ defmodule Thrift.Generator.Binary.Framed.Client do
     quote do
       def(unquote(function_name)(client, unquote_splicing(vars), rpc_opts \\ [])) do
         args = %unquote(args_module){unquote_splicing(assignments)}
-        serialized_args = unquote(args_binary_module).serialize(args)
+        serialized_args = unquote(args_module).serialize(args)
         unquote(build_response_handler(function, rpc_name, response_module))
       end
 
@@ -103,10 +102,8 @@ defmodule Thrift.Generator.Binary.Framed.Client do
   end
 
   defp build_response_handler(%Function{oneway: false}, rpc_name, response_module) do
-    module = Module.concat(response_module, :BinaryProtocol)
-
     quote do
-      ClientImpl.call(client, unquote(rpc_name), serialized_args, unquote(module), rpc_opts)
+      ClientImpl.call(client, unquote(rpc_name), serialized_args, unquote(response_module), rpc_opts)
     end
   end
 end

--- a/lib/thrift/generator/binary/framed/client.ex
+++ b/lib/thrift/generator/binary/framed/client.ex
@@ -103,7 +103,13 @@ defmodule Thrift.Generator.Binary.Framed.Client do
 
   defp build_response_handler(%Function{oneway: false}, rpc_name, response_module) do
     quote do
-      ClientImpl.call(client, unquote(rpc_name), serialized_args, unquote(response_module), rpc_opts)
+      ClientImpl.call(
+        client,
+        unquote(rpc_name),
+        serialized_args,
+        unquote(response_module),
+        rpc_opts
+      )
     end
   end
 end

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -69,7 +69,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
 
     quote do
       def handle_thrift(unquote(fn_name), binary_data, handler_module) do
-        case unquote(Module.concat(args_module, BinaryProtocol)).deserialize(binary_data) do
+        case unquote(args_module).deserialize(binary_data) do
           {%unquote(args_module){unquote_splicing(struct_matches)}, ""} ->
             unquote(build_handler_call(file_group, function, response_module))
 
@@ -104,7 +104,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
               response = %unquote(response_module){unquote(field_setter)}
 
               {:reply,
-               unquote(Module.concat(response_module, BinaryProtocol)).serialize(response)}
+               unquote(response_module).serialize(response)}
           end
       end)
 
@@ -144,7 +144,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
     quote do
       result = handler_module.unquote(handler_fn_name)(unquote_splicing(handler_args))
       response = %unquote(response_module){success: result}
-      {:reply, unquote(Module.concat(response_module, BinaryProtocol)).serialize(response)}
+      {:reply, unquote(response_module).serialize(response)}
     end
   end
 end

--- a/lib/thrift/generator/binary/framed/server.ex
+++ b/lib/thrift/generator/binary/framed/server.ex
@@ -103,8 +103,7 @@ defmodule Thrift.Generator.Binary.Framed.Server do
             :error, %unquote(dest_module){} = unquote(error_var) ->
               response = %unquote(response_module){unquote(field_setter)}
 
-              {:reply,
-               unquote(response_module).serialize(response)}
+              {:reply, unquote(response_module).serialize(response)}
           end
       end)
 

--- a/lib/thrift/generator/struct_binary_protocol.ex
+++ b/lib/thrift/generator/struct_binary_protocol.ex
@@ -222,7 +222,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
              <<unquote(Type.struct()), unquote(field.id)::16-signed, rest::binary>>,
              acc
            ) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
 
@@ -241,7 +241,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
              <<unquote(Type.struct()), unquote(field.id)::16-signed, rest::binary>>,
              acc
            ) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
 
@@ -260,7 +260,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
              <<unquote(Type.struct()), unquote(field.id)::16-signed, rest::binary>>,
              acc
            ) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(name)(rest, %{acc | unquote(field.name) => value})
 
@@ -435,7 +435,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(key_name)(<<rest::binary>>, stack) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {key, rest} ->
             unquote(value_name)(rest, key, stack)
 
@@ -451,7 +451,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(key_name)(<<rest::binary>>, stack) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {key, rest} ->
             unquote(value_name)(rest, key, stack)
 
@@ -467,7 +467,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(key_name)(<<rest::binary>>, stack) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {key, rest} ->
             unquote(value_name)(rest, key, stack)
 
@@ -655,7 +655,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(value_name)(<<rest::binary>>, key, [map, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
 
@@ -671,7 +671,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(value_name)(<<rest::binary>>, key, [map, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
 
@@ -687,7 +687,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(value_name)(<<rest::binary>>, key, [map, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {value, rest} ->
             unquote(key_name)(rest, [Map.put(map, key, value), remaining - 1 | stack])
 
@@ -865,7 +865,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(name)(<<rest::binary>>, [list, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {element, rest} ->
             unquote(name)(rest, [[element | list], remaining - 1 | stack])
 
@@ -881,7 +881,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(name)(<<rest::binary>>, [list, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {element, rest} ->
             unquote(name)(rest, [[element | list], remaining - 1 | stack])
 
@@ -897,7 +897,7 @@ defmodule Thrift.Generator.StructBinaryProtocol do
 
     quote do
       defp unquote(name)(<<rest::binary>>, [list, remaining | stack]) do
-        case unquote(Module.concat(dest_module, BinaryProtocol)).deserialize(rest) do
+        case unquote(dest_module).deserialize(rest) do
           {element, rest} ->
             unquote(name)(rest, [[element | list], remaining - 1 | stack])
 

--- a/lib/thrift/generator/struct_generator.ex
+++ b/lib/thrift/generator/struct_generator.ex
@@ -63,21 +63,10 @@ defmodule Thrift.Generator.StructGenerator do
         def new, do: %__MODULE__{}
         unquote_splicing(List.wrap(extra_defs))
 
-        defmodule BinaryProtocol do
-          @moduledoc false
-          unquote_splicing(binary_protocol_defs)
-        end
-
-        def serialize(struct) do
-          BinaryProtocol.serialize(struct)
-        end
+        unquote_splicing(binary_protocol_defs)
 
         def serialize(struct, :binary) do
-          BinaryProtocol.serialize(struct)
-        end
-
-        def deserialize(binary) do
-          BinaryProtocol.deserialize(binary)
+          serialize(struct)
         end
       end
     end

--- a/test/thrift/generator/service_test.exs
+++ b/test/thrift/generator/service_test.exs
@@ -177,7 +177,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameArgs{id: 1234, new_username: "stinkypants"}
-      |> UpdateUsernameArgs.BinaryProtocol.serialize()
+      |> UpdateUsernameArgs.serialize()
       |> IO.iodata_to_binary()
 
     assert <<10, 0, 1, 0, 0, 0, 0, 0, 0, 4, 210, 11, 0, 2, 0, 0, 0, 11, "stinkypants", 0>> ==
@@ -189,7 +189,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameResponse{success: true}
-      |> UpdateUsernameResponse.BinaryProtocol.serialize()
+      |> UpdateUsernameResponse.serialize()
       |> IO.iodata_to_binary()
 
     assert <<2, 0, 0, 1, 0>> == serialized
@@ -203,7 +203,7 @@ defmodule Thrift.Generator.ServiceTest do
 
     serialized =
       %UpdateUsernameResponse{taken: %UsernameTakenException{message: "That username is taken"}}
-      |> UpdateUsernameResponse.BinaryProtocol.serialize()
+      |> UpdateUsernameResponse.serialize()
       |> IO.iodata_to_binary()
 
     assert <<12, 0, 1, 11, 0, 1, 0, 0, 0, 22, rest::binary>> = serialized

--- a/test/thrift/protocol/binary_test.exs
+++ b/test/thrift/protocol/binary_test.exs
@@ -16,12 +16,11 @@ defmodule BinaryProtocolTest do
 
   defp assert_serde(%module{} = struct, thrift_binary_file) do
     thrift_binary_file = Path.join("test/data/binary", thrift_binary_file)
-    binary_protocol_module = Module.safe_concat(module, BinaryProtocol)
     thrift_binary = File.read!(thrift_binary_file)
 
-    serialized = serialize(binary_protocol_module, struct)
-    deserialized_test_data = deserialize(binary_protocol_module, thrift_binary)
-    assert deserialize(binary_protocol_module, serialized) == deserialized_test_data
+    serialized = serialize(module, struct)
+    deserialized_test_data = deserialize(module, thrift_binary)
+    assert deserialize(module, serialized) == deserialized_test_data
   end
 
   @thrift_file name: "enums.thrift",
@@ -236,8 +235,8 @@ defmodule BinaryProtocolTest do
       new_enum: Grooviness.partially_good()
     }
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -251,8 +250,8 @@ defmodule BinaryProtocolTest do
       new_substruct: sub_struct
     }
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -262,8 +261,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234", sub_sub: sub_sub}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_substruct: sub}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -272,8 +271,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_list: [sub]}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -282,8 +281,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_set: MapSet.new([sub, sub])}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -292,8 +291,8 @@ defmodule BinaryProtocolTest do
     sub = %SubStruct{password: "1234"}
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", new_map: %{1 => sub, 2 => sub}}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end
@@ -318,8 +317,8 @@ defmodule BinaryProtocolTest do
 
     changey = %ChangeyStruct{id: 12345, username: "stinkypants", my_twin: twin}
 
-    serialized = serialize(ChangeyStruct.BinaryProtocol, changey)
-    {deserialized, ""} = OldChangeyStruct.BinaryProtocol.deserialize(serialized)
+    serialized = serialize(ChangeyStruct, changey)
+    {deserialized, ""} = OldChangeyStruct.deserialize(serialized)
 
     assert %OldChangeyStruct{id: 12345, username: "stinkypants"} == deserialized
   end


### PR DESCRIPTION
A change in Elixir 1.13 prevents a nested module from referencing a struct defined by the parent module. We use this pattern in generated BinaryProtocol modules, which reference the struct defined by their parent, which corresponds to a Thrift struct.

Example code from the tests that won't compile in 1.13:

    defmodule Servers.Binary.Framed.IntegrationTest.IdAndName do
      @moduledoc false
      _ = "Auto-generated Thrift struct server_test.IdAndName"
      _ = "1: i64 id"
      _ = "2: string name"
      defstruct id: nil, name: nil
      @type t :: %__MODULE__{}
      def new do
        %__MODULE__{}
      end
      defmodule BinaryProtocol do
        @moduledoc false
        def deserialize(binary) do
          deserialize(binary, %Servers.Binary.Framed.IntegrationTest.IdAndName{})
        end

This diff eliminates the circular dependency by simply moving all of the serialize/deserialize implementation out of BinaryProtocol into the parent.

This will break client code that references the BinaryProtocol modules directly. However, the fix is a fairly straightforward search-and-replace.