### PR TITLE
Fix CI tests failing on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   format:
     name: Format (Elixir ${{ matrix.pair.elixir }} / OTP ${{ matrix.pair.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
         run: mix format --check-formatted
   test:
     name: Test (Elixir ${{ matrix.pair.elixir }} / OTP ${{ matrix.pair.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Tests on other PRs are failing with the following error:

    Error: Requested Erlang/OTP version (23) not found in version list (should you be using option 'version-type': 'strict'?)

I tried changing the Ubuntu version used in the CI environment based on Googling for ideas, and it seems to get the tests running.